### PR TITLE
improvement/core-client

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -34,7 +34,7 @@ shards:
 
   core:
     github: placeos/core
-    version: 1.1.0
+    version: 1.1.4
 
   cron_parser:
     github: kostya/cron_parser
@@ -82,7 +82,7 @@ shards:
 
   hound-dog:
     github: place-labs/hound-dog
-    version: 2.2.1
+    version: 2.3.1
 
   ipaddress:
     github: Sija/ipaddress.cr

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rest-api
-version: 1.5.1
+version: 1.6.0
 
 dependencies:
   # Server framework

--- a/spec/session_spec.cr
+++ b/spec/session_spec.cr
@@ -21,7 +21,6 @@ module PlaceOS::Api
           it "receives updates" do
             # Status to bind
             status_name = "nugget"
-            # ameba:disable Lint/ShadowingOuterLocalVar
             results = test_websocket_api(base, authorization_header) do |ws, control_system, mod|
               # Create a storage proxy
               driver_proxy = PlaceOS::Driver::Storage.new mod.id.as(String)
@@ -66,7 +65,6 @@ module PlaceOS::Api
           status_name = "nugget"
 
           id = rand(10).to_i64
-          # ameba:disable Lint/ShadowingOuterLocalVar
           results = test_websocket_api(base, authorization_header) do |ws, control_system, mod|
             request = {
               id:          id,

--- a/src/config.cr
+++ b/src/config.cr
@@ -26,7 +26,6 @@ require "action-controller/server"
 
 # Configure Service discovery
 HoundDog.configure do |settings|
-  settings.logger = logger
   settings.etcd_host = ENV["ETCD_HOST"]? || "localhost"
   settings.etcd_port = (ENV["ETCD_PORT"]? || 2379).to_i
 end

--- a/src/controllers/systems.cr
+++ b/src/controllers/systems.cr
@@ -32,9 +32,6 @@ module PlaceOS::Api
     # Websocket API session manager
     @@session_manager : Session::Manager? = nil
 
-    # Core API client
-    @core : PlaceOS::Core::Client? = nil
-
     # Core service discovery
     class_getter core_discovery = HoundDog::Discovery.new(CORE_NAMESPACE)
 
@@ -397,14 +394,16 @@ module PlaceOS::Api
       Core::Client.new(uri: self.locate_module(module_id), request_id: request_id)
     end
 
+    # Create a core client and yield it to a block
+    def self.core_for(module_id : String, request_id : String? = nil, & : Core::Client -> V) forall V
+      Core::Client.client(uri: self.locate_module(module_id), request_id: request_id) do |client|
+        yield client
+      end
+    end
+
     # Lazy initializer for session_manager
     def self.session_manager
       (@@session_manager ||= Session::Manager.new(@@core_discovery)).as(Session::Manager)
-    end
-
-    # Lazy getter for core client
-    def core
-      (@core ||= Core::Client.new(request_id: request.id)).as(Core::Client)
     end
 
     def current_system : Model::ControlSystem


### PR DESCRIPTION
- Use `PlaceOS::Core::Client`
- Include `compiled` bool in modules index response when filtering by `control_system_id`
- Include a `"compilation_status" => {"{{core_id}}" => {{compiled}}}` field in drivers' show. Included by default but can be ignored via explicitly setting `compilation_status` param to `false`. 