### PR TITLE
feat(controller:repositories): handle `Interface` type repositories

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -38,7 +38,7 @@ shards:
 
   core:
     github: placeos/core
-    version: 1.2.3
+    version: 1.2.4
 
   cron_parser:
     github: kostya/cron_parser
@@ -71,6 +71,10 @@ shards:
   faker:
     github: askn/faker
     version: 0.4.0
+
+  frontends:
+    github: placeos/frontend-loader
+    version: 0.3.0
 
   future:
     github: crystal-community/future.cr

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rest-api
-version: 1.7.2
+version: 1.8.0
 
 dependencies:
   # Server framework
@@ -25,6 +25,10 @@ dependencies:
   driver:
     github: placeos/driver
     version: ~> 1.2
+
+  # For frontends client
+  frontends:
+    github: placeos/frontend-loader
 
   # Database view
   models:


### PR DESCRIPTION
- Make the `driver` param for `GET ../repositories/:id/commits` optional
- Add `GET ../repositories/interfaces` to show loaded interfaces