### PR TITLE
refactor(controllers): set_collection_headers shortcut for fixed collections

### DIFF
--- a/src/placeos-rest-api/controllers/application.cr
+++ b/src/placeos-rest-api/controllers/application.cr
@@ -35,6 +35,11 @@ module PlaceOS::Api
       data[:results]
     end
 
+    def set_collection_headers(size : Int32, content_type : String)
+      response.headers["X-Total-Count"] = size.to_s
+      response.headers["Content-Range"] = "#{content_type} 0-#{size - 1}/#{size}"
+    end
+
     # Callbacks
     ###########################################################################
 

--- a/src/placeos-rest-api/controllers/brokers.cr
+++ b/src/placeos-rest-api/controllers/brokers.cr
@@ -14,9 +14,9 @@ module PlaceOS::Api
 
     def index
       brokers = Model::Broker.all.to_a
-      total_items = brokers.size
-      response.headers["X-Total-Count"] = total_items.to_s
-      response.headers["Content-Range"] = "broker 0-#{total_items}/#{total_items}"
+
+      set_collection_headers(brokers.size, Model::Broker.table_name)
+
       render json: brokers
     end
 

--- a/src/placeos-rest-api/controllers/modules.cr
+++ b/src/placeos-rest-api/controllers/modules.cr
@@ -54,7 +54,8 @@ module PlaceOS::Api
           })
         end.to_a
 
-        response.headers["X-Total-Count"] = results.size.to_s
+        set_collection_headers(results.size, Model::Module.table_name)
+
         render json: results
       else # we use Elasticsearch
         elastic = Model::Module.elastic

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -97,8 +97,7 @@ module PlaceOS::Api
     get "/with_emails", :find_by_email do
       emails = params["in"].split(',').map(&.strip).reject(&.empty?).uniq
       systems = Model::ControlSystem.get_all(emails, index: :email).to_a
-      response.headers["X-Total-Count"] = systems.size.to_s
-
+      set_collection_headers(systems.size, Model::ControlSystem.table_name)
       render json: systems
     end
 
@@ -170,9 +169,8 @@ module PlaceOS::Api
                     Model::Zone.get_all(zones).to_a
                   end
 
-      response_size = documents.size
-      response.headers["X-Total-Count"] = response_size.to_s
-      response.headers["Content-Range"] = "#{Model::Zone.table_name} 0-#{response_size}/#{response_size}"
+      set_collection_headers(documents.size, Model::Zone.table_name)
+
       render json: documents
     end
 

--- a/src/placeos-rest-api/controllers/triggers.cr
+++ b/src/placeos-rest-api/controllers/triggers.cr
@@ -52,9 +52,8 @@ module PlaceOS::Api
     # Get instances associated with
     get "/:id/instances", :instances do
       instances = current_trigger.trigger_instances.to_a
-      total_items = instances.size
-      response.headers["X-Total-Count"] = total_items.to_s
-      response.headers["Content-Range"] = "trigger-instance 0-#{total_items}/#{total_items}"
+
+      set_collection_headers(instances.size, Model::TriggerInstance.table_name)
 
       render json: instances
     end

--- a/src/placeos-rest-api/controllers/zones.cr
+++ b/src/placeos-rest-api/controllers/zones.cr
@@ -78,6 +78,14 @@ module PlaceOS::Api
       Missing
     end
 
+    # Return triggers attached to current zone
+    #
+    get "/:id/triggers", :trigger_instances do
+      triggers = current_zone.trigger_data
+      set_collection_headers(triggers.size, Model::Trigger.table_name)
+      render json: triggers
+    end
+
     # Execute a method on a module across all systems in a Zone
     post("/:id/exec/:module_slug/:method") do
       zone_id, module_slug, method = params["id"], params["module_slug"], params["method"]


### PR DESCRIPTION
DRY out setting of headers when returning a fixed-length query