### PR TITLE
feat(controller:repositories): support branch listing for interface repositories

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -69,8 +69,8 @@ shards:
     version: 0.4.4
 
   hardware:
-    git: https://github.com/caspiano/hardware.git
-    version: 0.6.0
+    git: https://github.com/crystal-community/hardware.git
+    version: 0.5.1
 
   hound-dog:
     git: https://github.com/place-labs/hound-dog.git
@@ -126,7 +126,7 @@ shards:
 
   placeos-frontends:
     git: https://github.com/placeos/frontend-loader.git
-    version: 0.9.0
+    version: 0.10.1
 
   placeos-models:
     git: https://github.com/placeos/models.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-rest-api
-version: 1.15.1
+version: 1.16.0
 
 targets:
   rest-api:
@@ -52,7 +52,7 @@ dependencies:
   # For frontends client
   placeos-frontends:
     github: placeos/frontend-loader
-    version: ~> 0.8
+    version: ~> 0.10
 
   # Database view
   placeos-models:


### PR DESCRIPTION
Adds a new route `GET ../repositories/:id/branches` that returns an `Array(String)` if  the `Repository` is of type `Interface`