### PR TITLE
fix(controller:metadata): default include parent metadata in children route

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-rest-api
-version: 1.16.4
+version: 1.16.5
 
 targets:
   rest-api:

--- a/src/placeos-rest-api/controllers/metadata.cr
+++ b/src/placeos-rest-api/controllers/metadata.cr
@@ -23,12 +23,22 @@ module PlaceOS::Api
 
     # Fetch metadata for Zone children
     #
-    # Filter for a specific metadata by name via `name` param
+    # Filter for a specific metadata by name via `name` param.
+    # Includes the parent metadata by default via `include_parent` param.
     get "/:id/children", :children_metadata do
+      parent_id = params["id"]
       name = params["name"]?
-      parent_id = current_zone.id
 
-      results = current_zone.children.all.reject { |z| z.id == parent_id }.map do |zone|
+      include_parent = if (_include = params["include_parent"]?)
+                         _include == "true"
+                       else
+                         true
+                       end
+
+      children = current_zone.children.all
+      filtered = include_parent ? children : children.reject { |z| z.id == parent_id }
+
+      results = filtered.map do |zone|
         {
           zone:     zone,
           metadata: Model::Metadata.build_metadata(zone, name),


### PR DESCRIPTION
Include the parent Zone's metadata via the default `true` param `include_parent`

fixes #47