### PR TITLE
chore: add test script, update docs for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 bin
 docs
 lib
+data

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,5 @@
-language: crystal
-
 services:
   - docker
-  - redis-server
-
-before_install:
-  # Add elasticsearch 7.6.x
-  - docker run --net="host" -p "9300:9300" -p "9200:9200" -e discovery.type=single-node -d blacktop/elasticsearch:7.6
-  # Add rethinkdb 2.3.6
-  - docker run --net="host" -p "29015:29015" -p "28015:28015" -d rethinkdb:2.4
-  # Add latest rubber-soul (mirrors RethinkDB tables to elasticsearch indices)
-  - docker run --net="host" -e RETHINKDB_DB="place_production" -e RETHINKDB_PORT="28015" -e RETHINKDB_HOST="127.0.0.1" -e ES_PORT="9200" -e ES_HOST="127.0.0.1" --restart=always -d placeos/rubber-soul:latest
-  # Add etcd 3.3.13
-  - docker run --net="host" -p "2379:2379" -p "2380:2380" -e ALLOW_NONE_AUTHENTICATION=yes -d bitnami/etcd:3.3.13
-
-env:
-  # Set spider-gazelle environment
-  - SG_ENV=production
 
 install:
-  - shards install
-
-before_script:
-  # Wait for elasticsearch
-  - sleep 10
-
-script:
-  # Specs
-  - crystal spec -v --error-trace
-  - crystal spec -v -Dpreview_mt --error-trace
-  # Linter
-  - bin/ameba
-  # Formatter
-  - crystal tool format --check
+  - ./test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -7,6 +7,7 @@ ARG PLACE_COMMIT="DEV"
 
 # Add trusted CAs for communicating with external services
 RUN apk update && apk add --no-cache ca-certificates tzdata && update-ca-certificates
+RUN apk add watchexec --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
 COPY shard.yml /app
 COPY shard.lock /app

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,25 @@
+FROM crystallang/crystal:0.35.1-alpine
+
+WORKDIR /app
+
+# Set the commit through a build arg
+ARG PLACE_COMMIT="DEV"
+
+# Add trusted CAs for communicating with external services
+RUN apk update && apk add --no-cache ca-certificates tzdata && update-ca-certificates
+
+COPY shard.yml /app
+COPY shard.lock /app
+RUN shards install
+
+COPY src /app/src
+COPY spec /app/spec
+RUN mkdir -p /app/bin/drivers
+
+RUN crystal tool format --check
+RUN crystal lib/ameba/bin/ameba.cr
+
+# These provide certificate chain validation where communicating with external services over TLS
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+ENTRYPOINT crystal spec --error-trace -v

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - `crystal spec` to run tests
 
 **Dependencies**
+
 - Elasticsearch `~> v7.2`
 - RethinkDB `~> v2.3.6`
 - Etcd `~> v3.3.13`
@@ -16,10 +17,12 @@
 
 ### With Docker
 
-- `$ ./test`
+- `$ ./test` (tear down the docker-compose environment)
+- `$ ./test --watch` (only run tests on change)
 - `$ docker-compose down` when you are done with development work for the day
 
 **Dependencies**
+
 - [docker](https://www.docker.com/)
 - [docker-compose](https://github.com/docker/compose)
 - [git](https://git-scm.com/)
@@ -32,9 +35,9 @@
 
 Once compiled you are left with a binary `./rest-api`
 
-* for help `./rest-api --help`
-* viewing routes `./rest-api --routes`
-* run on a different port or host `./rest-api -b 0.0.0.0 -p 80`
+- for help `./rest-api --help`
+- viewing routes `./rest-api --routes`
+- run on a different port or host `./rest-api -b 0.0.0.0 -p 80`
 
 ## Inspecting minimal images
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,29 @@
 
 ## Testing
 
-`crystal spec` to run tests
+### Without Docker
 
-## Compiling
+- `crystal spec` to run tests
 
-`crystal build ./src/rest-api.cr`
-
-## Dependencies
-
+**Dependencies**
 - Elasticsearch `~> v7.2`
 - RethinkDB `~> v2.3.6`
 - Etcd `~> v3.3.13`
 - Redis `~> v5`
+
+### With Docker
+
+- `$ ./test`
+- `$ docker-compose down` when you are done with development work for the day
+
+**Dependencies**
+- [docker](https://www.docker.com/)
+- [docker-compose](https://github.com/docker/compose)
+- [git](https://git-scm.com/)
+
+## Compiling
+
+`crystal build ./src/rest-api.cr`
 
 ### Deploying
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,132 @@
+version: "3.7"
+
+networks:
+  placeos:
+    name: placeos
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.31.231.0/24
+
+# YAML Anchors
+
+x-deployment-env: &deployment-env
+  ENV: ${ENV:-development}
+  SG_ENV: ${SG_ENV:-development}
+  TZ: $TZ
+
+x-elastic-client-env: &elastic-client-env
+  ES_HOST: ${ELASTIC_HOST:-elastic}
+  ES_PORT: ${ELASTIC_PORT:-9200}
+
+x-etcd-client-env: &etcd-client-env
+  ETCD_HOST: ${ETCD_HOST:-etcd}
+  ETCD_PORT: ${ETCD_PORT:-2379}
+
+x-redis-client-env: &redis-client-env
+  REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+
+x-rethinkdb-client-env: &rethinkdb-client-env
+  RETHINKDB_HOST: ${RETHINKDB_HOST:-rethink}
+  RETHINKDB_PORT: ${RETHINKDB_PORT:-28015}
+  RETHINKDB_DB: ${RETHINKDB_DB:-place_development}
+
+services:
+  elastic:
+    image: blacktop/elasticsearch:${ELASTIC_VERSION:-7.6}
+    restart: always
+    container_name: elastic
+    hostname: elastic
+    expose:
+      - 9200
+    ports:
+      - 127.0.0.1:8090:9200
+    networks:
+      placeos:
+        ipv4_address: 172.31.231.10
+    environment:
+      discovery.type: single-node
+
+  etcd:
+    image: bitnami/etcd:${ETCD_VERSION:-3.3.13}
+    restart: always
+    container_name: etcd
+    hostname: etcd
+    ports:
+      - 127.0.0.1:8091:2379
+      - 127.0.0.1:8092:2380
+    networks:
+      placeos:
+        ipv4_address: 172.31.231.11
+    environment:
+      ALLOW_NONE_AUTHENTICATION: "yes"
+
+  redis:
+    image: eqalpha/keydb
+    restart: always
+    container_name: redis
+    hostname: redis
+    ports:
+      - 127.0.0.1:7379:6379
+    networks:
+      placeos:
+        ipv4_address: 172.31.231.13
+
+  rethink:
+    image: rethinkdb:${RETHINKDB_VERSION:-2.4}
+    restart: always
+    container_name: rethink
+    hostname: rethink
+    ports:
+      - 127.0.0.1:8093:8080
+    networks:
+      placeos:
+        ipv4_address: 172.31.231.14
+
+  rubber-soul: # RethinkDB to Elasticsearch Service
+    image: placeos/rubber-soul:${PLACE_RUBBER_SOUL_TAG:-latest}
+    restart: always
+    container_name: rubber-soul
+    hostname: rubber-soul
+    ports:
+      - 127.0.0.1:8084:3000
+    networks:
+      placeos:
+        ipv4_address: 172.31.231.8
+    depends_on:
+      - elastic
+      - rethink
+    environment:
+      # Service Hosts
+      << : *rethinkdb-client-env
+      << : *elastic-client-env
+      # Environment
+      << : *deployment-env
+
+  api: # Rest API
+    build:
+      context: ./
+      dockerfile: Dockerfile.test
+    restart: always
+    container_name: api
+    hostname: api
+    ports:
+      - 127.0.0.1:8082:3000
+    networks:
+      placeos:
+        ipv4_address: 172.31.231.2
+    depends_on:
+      - elastic
+      - etcd
+      - redis
+      - rethink
+      - rubber-soul
+    environment:
+      # Environment
+      << : *deployment-env
+      # Service Hosts
+      << : *elastic-client-env
+      << : *etcd-client-env
+      << : *redis-client-env
+      << : *rethinkdb-client-env

--- a/test
+++ b/test
@@ -1,0 +1,1 @@
+docker-compose build && docker-compose run --rm api


### PR DESCRIPTION
This is essentially the same structure as the docker-compose and `$ ./test` script as in `core`.

I have not made any significant changes from the partner-env docker-compose

However there is some issue with `rubber-soul` that I have been running into now as well as when I was working on this last Friday. Particularly, `rubber-soul` always seems to fail to connect to `elastic` or `rethink` (more often `elastic` I think), which forces one of the db services and `rubber-soul` to take turn restarting infinitely (during `docker run --rm api`. Only when I abort operation with CTRL + C (but not `docker-compose down`, does `rubber-soul` successfully connects and responds. However by this time, `api` cannot be started (because operation has been aborted).

docker-compose run --rm api logs
https://gist.github.com/dukeraphaelng/46c71ee5daa7d57c11061268795224c9

docker-compose logs before and after CTRL + C
https://gist.github.com/dukeraphaelng/e653f96cc10499fc52a45db6858ddc55