### PR TITLE
refactor: use `limit` rather than `count` for commit listing

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-rest-api
-version: 1.17.11
+version: 1.18.0
 
 targets:
   rest-api:

--- a/src/placeos-rest-api/controllers/repositories.cr
+++ b/src/placeos-rest-api/controllers/repositories.cr
@@ -124,7 +124,7 @@ module PlaceOS::Api
     end
 
     get "/:id/commits", :commits do
-      number_of_commits = params["count"]?.try &.to_i
+      number_of_commits = params["limit"]?.try &.to_i
       file_name = params["driver"]?
 
       commits = Api::Repositories.commits(


### PR DESCRIPTION
A small change to the `Repositories` controller.
Previously limiting the number of commits was done via a `count` param, now the param 
`limit` is used.