### PR TITLE
feat: edge to core proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     hostname: rethink
 
   rubber-soul: # RethinkDB to Elasticsearch Service
-    image: placeos/rubber-soul:${PLACE_RUBBER_SOUL_TAG:-latest}
+    image: placeos/rubber-soul:${PLACE_RUBBER_SOUL_TAG:-edge}
     restart: always
     hostname: rubber-soul
     depends_on:

--- a/shard.lock
+++ b/shard.lock
@@ -14,7 +14,7 @@ shards:
 
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 0.13.2
+    version: 0.13.3
 
   bindata:
     git: https://github.com/spider-gazelle/bindata.git
@@ -130,11 +130,11 @@ shards:
 
   placeos-frontends:
     git: https://github.com/placeos/frontends.git
-    version: 0.10.6
+    version: 0.10.8
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 4.7.0
+    version: 4.8.2
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git
@@ -182,7 +182,7 @@ shards:
 
   rubber-soul:
     git: https://github.com/placeos/rubber-soul.git
-    version: 1.15.0
+    version: 1.15.1
 
   rwlock:
     git: https://github.com/spider-gazelle/readers-writer.git

--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   action-controller:
     git: https://github.com/spider-gazelle/action-controller.git
-    version: 3.4.0
+    version: 3.4.1
 
   active-model:
     git: https://github.com/spider-gazelle/active-model.git
@@ -69,8 +69,8 @@ shards:
     version: 0.4.4
 
   hardware:
-    git: https://github.com/caspiano/hardware.git
-    version: 0.6.0
+    git: https://github.com/crystal-community/hardware.git
+    version: 0.5.2
 
   hound-dog:
     git: https://github.com/place-labs/hound-dog.git
@@ -98,7 +98,7 @@ shards:
 
   lucky_router:
     git: https://github.com/luckyframework/lucky_router.git
-    version: 0.3.1
+    version: 0.4.0
 
   murmur3:
     git: https://github.com/aca-labs/murmur3.git
@@ -122,7 +122,7 @@ shards:
 
   placeos-core:
     git: https://github.com/placeos/core.git
-    version: 2.5.3
+    version: 3.0.0+git.commit.17c6bba784eedbd401e6036123d625b74b4426c6
 
   placeos-driver:
     git: https://github.com/placeos/driver.git
@@ -134,7 +134,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 4.8.2
+    version: 4.8.3
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git
@@ -157,7 +157,7 @@ shards:
     version: 2.2.2
 
   redis:
-    git: https://github.com/stefanwille/crystal-redis.git
+    git: https://github.com/maiha/crystal-redis.git
     version: 2.6.0
 
   redis-cluster:

--- a/shard.yml
+++ b/shard.yml
@@ -44,7 +44,7 @@ dependencies:
   # For core client
   placeos-core:
     github: placeos/core
-    version: ~> 2.4
+    branch: feat/edge
 
   # For driver state helpers
   placeos-driver:

--- a/spec/edges_spec.cr
+++ b/spec/edges_spec.cr
@@ -1,0 +1,21 @@
+require "./helper"
+
+module PlaceOS::Api
+  describe Edges do
+    # ameba:disable Lint/UselessAssign
+    authenticated_user, authorization_header = authentication
+    base = Edges::NAMESPACE[0]
+
+    with_server do
+      test_404(base, model_name: Model::Edge.table_name, headers: authorization_header)
+
+      describe "index", tags: "search" do
+        test_base_index(Model::Edge, Edges)
+      end
+
+      describe "CRUD operations", tags: "crud" do
+        test_crd(Model::Edge, Edges)
+      end
+    end
+  end
+end

--- a/src/placeos-rest-api/controllers/application.cr
+++ b/src/placeos-rest-api/controllers/application.cr
@@ -7,13 +7,18 @@ require "../utilities/*"
 
 module PlaceOS::Api
   private abstract class Application < ActionController::Base
-    Log = ::PlaceOS::Api::Log.for("controller")
+    macro inherited
+      Log = ::PlaceOS::Api::Log.for("controller").for({{ @type.stringify.split("::").last.underscore }})
+    end
 
     # Helpers for controller responses
     include Utils::Responders
 
     # Helpers for determining picking off user from JWT, authorization
     include Utils::CurrentUser
+
+    # Core service discovery
+    class_getter core_discovery : Discovery::Core { Discovery::Core.instance }
 
     # Default sort for elasticsearch
     NAME_SORT_ASC = {"name.keyword" => {order: :asc}}

--- a/src/placeos-rest-api/controllers/authentications.cr
+++ b/src/placeos-rest-api/controllers/authentications.cr
@@ -10,6 +10,7 @@ module PlaceOS::Api
       before_action :check_support, only: [:index, :show]
 
       before_action :current_auth, only: [:show, :update, :update_alt, :destroy]
+      before_action :body, only: [:create, :update, :update_alt]
 
       getter current_auth : Model::{{auth_type.id}}Authentication { find_auth }
 
@@ -32,16 +33,15 @@ module PlaceOS::Api
       end
 
       def update
-        auth = current_auth
-        auth.assign_attributes_from_json(request.body.as(IO))
-        save_and_respond auth
+        current_auth.assign_attributes_from_json(self.body)
+        save_and_respond current_auth
       end
 
       # TODO: replace manual id with interpolated value from `id_param`
       put "/:id", :update_alt { update }
 
       def create
-        save_and_respond(Model::{{auth_type.id}}Authentication.from_json(request.body.as(IO)))
+        save_and_respond(Model::{{auth_type.id}}Authentication.from_json(self.body))
       end
 
       def destroy

--- a/src/placeos-rest-api/controllers/brokers.cr
+++ b/src/placeos-rest-api/controllers/brokers.cr
@@ -9,6 +9,7 @@ module PlaceOS::Api
     before_action :check_support, only: [:index, :show]
 
     before_action :current_broker, only: [:show, :update, :update_alt, :destroy]
+    before_action :body, only: [:create, :update, :update_alt]
 
     getter current_broker : Model::Broker { find_broker }
 
@@ -25,14 +26,14 @@ module PlaceOS::Api
     end
 
     def update
-      save_and_respond current_broker.assign_attributes_from_json(request.body.as(IO))
+      save_and_respond current_broker.assign_attributes_from_json(self.body)
     end
 
     # TODO: replace manual id with interpolated value from `id_param`
     put "/:id", :update_alt { update }
 
     def create
-      save_and_respond(Model::Broker.from_json(request.body.as(IO)))
+      save_and_respond(Model::Broker.from_json(self.body))
     end
 
     def destroy

--- a/src/placeos-rest-api/controllers/cluster.cr
+++ b/src/placeos-rest-api/controllers/cluster.cr
@@ -7,7 +7,7 @@ module PlaceOS::Api
     before_action :check_admin
 
     def index
-      details = Api::Systems.core_discovery.node_hash
+      details = self.class.core_discovery.node_hash
 
       if params["include_status"]?
         # Returns Array(NodeStatus)
@@ -82,7 +82,7 @@ module PlaceOS::Api
 
     def show
       core_id = params["id"]
-      uri = Api::Systems.core_discovery.node_hash[core_id]
+      uri = self.class.core_discovery.node_hash[core_id]
       Core::Client.client(uri, request_id) do |client|
         drivers = client.loaded
 
@@ -117,7 +117,7 @@ module PlaceOS::Api
       core_id = params["id"]
       driver = params["driver"]
 
-      uri = Api::Systems.core_discovery.node_hash[core_id]
+      uri = self.class.core_discovery.node_hash[core_id]
       if Core::Client.client(uri, request_id) { |client| client.terminate(driver) }
         head :ok
       else

--- a/src/placeos-rest-api/controllers/cluster.cr
+++ b/src/placeos-rest-api/controllers/cluster.cr
@@ -60,14 +60,13 @@ module PlaceOS::Api
       nil
     end
 
-    # Collect unique driver keys managed by a node
+    # Collect unique driver keys managed by a core node
     #
     def self.collect_keys(loaded : PlaceOS::Core::Client::Loaded)
-      # Retain only the driver key
       loaded.edge
-        .values.flat_map(&.keys)
-        .concat(loaded.local.keys)
-        .map { |k| k.split('/').last }
+        .flat_map(&.last.keys)        # Extract driver keys from each edge bound to the core
+        .concat(loaded.local.keys)    # Extract driver keys from the core
+        .map!(&.rpartition('/').last) # Strip any path prefix, retaining only the driver key
         .to_set
     end
 

--- a/src/placeos-rest-api/controllers/domains.cr
+++ b/src/placeos-rest-api/controllers/domains.cr
@@ -8,6 +8,7 @@ module PlaceOS::Api
     before_action :check_support, only: [:index, :show]
 
     before_action :current_domain, only: [:show, :update, :update_alt, :destroy]
+    before_action :body, only: [:create, :update, :update_alt]
 
     getter current_domain : Model::Authority { find_domain }
 
@@ -24,7 +25,7 @@ module PlaceOS::Api
 
     def update
       domain = current_domain
-      domain.assign_attributes_from_json(request.body.as(IO))
+      domain.assign_attributes_from_json(self.body)
       save_and_respond domain
     end
 
@@ -32,7 +33,7 @@ module PlaceOS::Api
     put "/:id", :update_alt { update }
 
     def create
-      save_and_respond(Model::Authority.from_json(request.body.as(IO)))
+      save_and_respond(Model::Authority.from_json(self.body))
     end
 
     def destroy

--- a/src/placeos-rest-api/controllers/domains.cr
+++ b/src/placeos-rest-api/controllers/domains.cr
@@ -24,9 +24,8 @@ module PlaceOS::Api
     end
 
     def update
-      domain = current_domain
-      domain.assign_attributes_from_json(self.body)
-      save_and_respond domain
+      current_domain.assign_attributes_from_json(self.body)
+      save_and_respond current_domain
     end
 
     # TODO: replace manual id with interpolated value from `id_param`

--- a/src/placeos-rest-api/controllers/drivers.cr
+++ b/src/placeos-rest-api/controllers/drivers.cr
@@ -8,6 +8,7 @@ module PlaceOS::Api
     before_action :check_support, only: [:index, :show]
 
     before_action :current_driver, only: [:show, :update, :update_alt, :destroy, :recompile]
+    before_action :body, only: [:create, :update, :update_alt]
 
     getter current_driver : Model::Driver { find_driver }
 
@@ -48,7 +49,7 @@ module PlaceOS::Api
 
     def update
       driver = current_driver
-      driver.assign_attributes_from_json(request.body.as(IO))
+      driver.assign_attributes_from_json(self.body)
 
       # Must destroy and re-add to change driver type
       render :unprocessable_entity, text: "Error: role must not change" if driver.role_changed?
@@ -60,7 +61,7 @@ module PlaceOS::Api
     put "/:id", :update_alt { update }
 
     def create
-      save_and_respond(Model::Driver.from_json(request.body.as(IO)))
+      save_and_respond(Model::Driver.from_json(self.body))
     end
 
     def destroy

--- a/src/placeos-rest-api/controllers/drivers.cr
+++ b/src/placeos-rest-api/controllers/drivers.cr
@@ -162,7 +162,7 @@ module PlaceOS::Api
       tag = driver.id.as(String)
       repository_folder = driver.repository!.folder_name
 
-      nodes = Api::Systems.core_discovery.node_hash
+      nodes = core_discovery.node_hash
       result = Promise.all(nodes.map { |name, uri|
         Promise.defer {
           status = begin

--- a/src/placeos-rest-api/controllers/edge.cr
+++ b/src/placeos-rest-api/controllers/edge.cr
@@ -8,13 +8,75 @@ module PlaceOS::Api
   class Edge < Application
     base "/api/engine/v2/edge/"
 
-    class_getter core_discovery = Systems.core_discovery
+    class_getter core_discovery : Discovery::Core { Discovery::Core.instance }
 
-    # TODO: use a single socket per core
-    getter edge_sockets = {} of {String, String} => {HTTP::WebSocket, HTTP::WebSocket}
+    class_getter connection_manager : ConnectionManager { ConnectionManager.new(core_discovery) }
+
+    # Handles the websocket proxy between Edge and Core
+    #
+    # TODO: Use a single socket per core
+    class ConnectionManager
+      Log = ::Log.for(self)
+
+      private getter edge_mapping = {} of String => HoundDog::Service::Node
+
+      private getter edge_sockets = {} of String => HTTP::WebSocket
+      private getter core_sockets = {} of String => HTTP::WebSocket
+
+      private getter edge_lock = Mutex.new
+
+      getter discovery : HoundDog::Discovery
+
+      def initialize(@discovery : Api::Discovery::Core)
+        @discovery.callbacks << ->rebalance(Array(HoundDog::Node))
+      end
+
+      def add_edge_connection(edge_id : String, socket : HTTP::WebSocket)
+        edge_lock.synchronize do
+          edge_sockets[edge_id] = socket
+          new_core_connection(edge_id, core_discovery.find(edge_id))
+        end
+      end
+
+      def new_core_connection(edge_id : String, node : HoundDog::Service::Node)
+        uri = node[:uri].dup
+        uri.query("edge_id=#{edge_id}")
+        uri.path("/api/v1/edge")
+
+        edge_lock.synchronize do
+          edge_socket = edge_sockets[edge_id]
+          core_socket = HTTP::Websocket.new(uri)
+
+          # Link core to edge
+          core_socket.on_message { |message| edge_socket.send(message) }
+          core_socket.on_binary { |bytes| edge_socket.stream &.write(bytes) }
+
+          # Link edge to core
+          edge_socket.on_message { |message| core_socket.send(message) }
+          edge_socket.on_binary { |bytes| core_socket.stream &.write(bytes) }
+
+          core_sockets[edge_id]?.try(&.close) rescue nil
+          core_sockets[edge_id] = core_socket
+        end
+
+        spawn { core_socket.run }
+
+        core_socket
+      end
+
+      def rebalance(node : Array(HoundDog::Node))
+        Log.info { "rebalancing edge connections" }
+        edge_lock.synchronize do
+          edge_mapping.each do |edge_id, core_node|
+            new_core = core_discovery.find(edge_id)
+            new_core_connection(edge_id, new_core) unless new_core[:name] == core_node[:name]
+          end
+        end
+      end
+    end
 
     # Validate the present of the id and check the secret before routing to core
-    ws("/", :edge) do |ws|
+    ws("/", :edge) do |_ws|
     end
   end
 end

--- a/src/placeos-rest-api/controllers/edge.cr
+++ b/src/placeos-rest-api/controllers/edge.cr
@@ -8,8 +8,6 @@ module PlaceOS::Api
   class Edge < Application
     base "/api/engine/v2/edge/"
 
-    class_getter core_discovery : Discovery::Core { Discovery::Core.instance }
-
     class_getter connection_manager : ConnectionManager { ConnectionManager.new(core_discovery) }
 
     # Handles the websocket proxy between Edge and Core

--- a/src/placeos-rest-api/controllers/edge.cr
+++ b/src/placeos-rest-api/controllers/edge.cr
@@ -1,5 +1,6 @@
 require "hound-dog"
 require "placeos-core/client"
+require "promise"
 
 require "./application"
 require "./systems"
@@ -17,33 +18,77 @@ module PlaceOS::Api
       Log = ::Log.for(self)
 
       private getter edge_mapping = {} of String => HoundDog::Service::Node
-
       private getter edge_sockets = {} of String => HTTP::WebSocket
       private getter core_sockets = {} of String => HTTP::WebSocket
 
       private getter edge_lock = Mutex.new
 
-      getter discovery : HoundDog::Discovery
+      getter core_discovery : Api::Discovery::Core
 
-      def initialize(@discovery : Api::Discovery::Core)
-        @discovery.callbacks << ->rebalance(Array(HoundDog::Node))
+      def initialize(@core_discovery : Api::Discovery::Core)
+        @core_discovery.callbacks << ->rebalance(Array(HoundDog::Service::Node))
       end
 
-      def add_edge_connection(edge_id : String, socket : HTTP::WebSocket)
+      def add_edge(edge_id : String, socket : HTTP::WebSocket)
         edge_lock.synchronize do
           edge_sockets[edge_id] = socket
-          new_core_connection(edge_id, core_discovery.find(edge_id))
+          socket.on_close { remove(edge_id) }
+          add_core(edge_id, current_node: core_discovery.find(edge_id))
         end
       end
 
-      def new_core_connection(edge_id : String, node : HoundDog::Service::Node)
-        uri = node[:uri].dup
-        uri.query("edge_id=#{edge_id}")
-        uri.path("/api/v1/edge")
-
+      def remove(edge_id : String)
         edge_lock.synchronize do
+          mapping = edge_mapping.delete(edge_id)
+          uri = mapping.try &.[:uri].to_s
+
+          if socket = core_sockets.delete(edge_id)
+            socket.close rescue nil
+            Log.info { {message: "closed socket to core", edge_id: edge_id, core_uri: uri} }
+          end
+
+          if socket = edge_sockets.delete(edge_id)
+            socket.close rescue nil
+            Log.info { {message: "closed socket to edge", edge_id: edge_id, core_uri: uri} }
+          end
+        end
+      end
+
+      def add_core(
+        edge_id : String,
+        rendezvous : RendezvousHash = core_discovery.rendezvous,
+        current_node : HoundDog::Service::Node? = nil,
+        reconnect : Bool = false
+      )
+        node = rendezvous[edge_id]?.try &->HoundDog::Discovery.from_hash_value(String)
+        return if node.nil? || (!reconnect && current_node && node && node[:name] == current_node[:name])
+
+        uri = node[:uri].dup
+        uri.query = "edge_id=#{edge_id}"
+        uri.path = "/api/v1/edge"
+
+        socket = edge_lock.synchronize do
           edge_socket = edge_sockets[edge_id]
-          core_socket = HTTP::Websocket.new(uri)
+          core_socket = HTTP::WebSocket.new(uri)
+          core_socket.on_close do
+            begin
+              Retriable.retry(
+                max_interval: 5.seconds,
+                max_elapsed_time: 1.minute,
+                on_retry: ->(error : Exception, _i : Int32, _e : Time::Span, _p : Time::Span) {
+                  Log.warn { {error: error.to_s, edge_id: edge_id, message: "reconnecting edge to core"} }
+                }) do
+                add_core(edge_id, reconnect: true) if edge_mapping.has_key?(edge_id)
+              end
+            rescue error
+              Log.error { {
+                message:  "failed to reconnect to core",
+                edge_id:  edge_id,
+                core_uri: edge_mapping[edge_id]?.try &.[:uri].to_s,
+              } }
+              remove(edge_id)
+            end
+          end
 
           # Link core to edge
           core_socket.on_message { |message| edge_socket.send(message) }
@@ -55,26 +100,70 @@ module PlaceOS::Api
 
           core_sockets[edge_id]?.try(&.close) rescue nil
           core_sockets[edge_id] = core_socket
+          core_socket
         end
 
-        spawn { core_socket.run }
-
-        core_socket
+        spawn { socket.run }
+        socket
       end
 
-      def rebalance(node : Array(HoundDog::Node))
+      def rebalance(nodes : Array(HoundDog::Service::Node))
         Log.info { "rebalancing edge connections" }
+
+        rendezvous = RendezvousHash.new(nodes.map(&->HoundDog::Discovery.to_hash_value(HoundDog::Service::Node)))
+
         edge_lock.synchronize do
-          edge_mapping.each do |edge_id, core_node|
-            new_core = core_discovery.find(edge_id)
-            new_core_connection(edge_id, new_core) unless new_core[:name] == core_node[:name]
-          end
+          # Asynchronously refresh core connections
+          Promise.map(edge_mapping) do |(edge_id, core_node)|
+            begin
+              Retriable.retry(max_interval: 1.seconds, max_elapsed_time: 20.seconds, on_retry: ->(e : Exception, _i : Int32, _e : Time::Span, _p : Time::Span) {
+                Log.warn { {error: e.to_s, edge_id: edge_id, message: "retrying connection to core"} }
+              }) do
+                add_core(edge_id, current_node: core_node, rendezvous: rendezvous)
+              end
+            rescue error
+              Log.error(exception: error) { {message: "failed to connect to core", edge_id: edge_id} }
+              remove(edge_id)
+            end
+          end.get
         end
       end
     end
 
+    # Check the validity of the token.
+    # Returns the `edge_id` of the node if the token is valid.
+    def self.validate_token(token : String) : String?
+      parts = token.split('_')
+      unless parts.size == 2
+        Log.info { {message: "deformed token", token: token} }
+        return
+      end
+
+      edge_id, secret = parts
+
+      edge = Model::Edge.find(edge_id)
+      if edge.nil?
+        Log.info { {message: "edge not found", edge_id: edge_id} }
+        return
+      end
+
+      if edge.check_secret?(secret)
+        edge_id
+      else
+        Log.info { {message: "edge secret is invalid", edge_id: edge_id} }
+        nil
+      end
+    end
+
     # Validate the present of the id and check the secret before routing to core
-    ws("/", :edge) do |_ws|
+    ws("/", :edge) do |socket|
+      token = params["token"]?
+      render status: :unprocessable_entity, json: {error: "missing 'token' param"} if token.nil? || token.presence.nil?
+
+      edge_id = Edge.validate_token(token)
+      head status: :unauthorized if edge_id.nil?
+
+      Edge.connection_manager.add_edge(edge_id, socket)
     end
   end
 end

--- a/src/placeos-rest-api/controllers/edge.cr
+++ b/src/placeos-rest-api/controllers/edge.cr
@@ -1,0 +1,20 @@
+require "hound-dog"
+require "placeos-core/client"
+
+require "./application"
+require "./systems"
+
+module PlaceOS::Api
+  class Edge < Application
+    base "/api/engine/v2/edge/"
+
+    class_getter core_discovery = Systems.core_discovery
+
+    # TODO: use a single socket per core
+    getter edge_sockets = {} of {String, String} => {HTTP::WebSocket, HTTP::WebSocket}
+
+    # Validate the present of the id and check the secret before routing to core
+    ws("/", :edge) do |ws|
+    end
+  end
+end

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -26,7 +26,7 @@ module PlaceOS::Api
     ws("/control", :edge) do |socket|
       token = params["token"]?
 
-      render status: :unprocessable_entity, json: {error: "missing 'token' param"} if token.nil? || token.presence.nil?
+      render status: :bad_request, json: {error: "missing 'token' param"} if token.nil? || token.presence.nil?
 
       edge_id = Model::Edge.validate_token(token)
       head status: :unauthorized if edge_id.nil?
@@ -37,7 +37,7 @@ module PlaceOS::Api
     end
 
     get("/:id/token", :token) do
-      head :unauthorized unless is_admin?
+      head :forbidden unless is_admin?
       render json: {token: current_edge.token(current_user)}
     end
 

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -13,6 +13,7 @@ module PlaceOS::Api
     before_action :check_support, only: [:index, :show]
 
     before_action :current_edge, only: [:destroy, :drivers, :show, :update, :update_alt, :token]
+    before_action :body, only: [:create, :update, :update_alt]
 
     skip_action :authorize!, only: [:edge]
     skip_action :set_user_id, only: [:edge]
@@ -54,7 +55,7 @@ module PlaceOS::Api
 
     def update
       edge = current_edge
-      edge.assign_attributes_from_json(request.body.as(IO))
+      edge.assign_attributes_from_json(self.body)
       save_and_respond edge
     end
 
@@ -62,7 +63,7 @@ module PlaceOS::Api
     put "/:id", :update_alt { update }
 
     def create
-      save_and_respond(Model::Edge.from_json(request.body.as(IO)))
+      save_and_respond(Model::Edge.from_json(self.body))
     end
 
     def destroy

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -176,11 +176,18 @@ module PlaceOS::Api
           end
 
           # Link core to edge
-          core_socket.on_message { |message| edge_socket.send(message) }
+          core_socket.on_message { |message|
+            Log.debug { {message: "from core", packet: message} }
+            edge_socket.send(message)
+          }
           core_socket.on_binary { |bytes| edge_socket.stream &.write(bytes) }
 
           # Link edge to core
-          edge_socket.on_message { |message| core_socket.send(message) }
+          edge_socket.on_message { |message|
+            Log.debug { {message: "from edge", packet: message} }
+            core_socket.send(message)
+          }
+
           edge_socket.on_binary { |bytes| core_socket.stream &.write(bytes) }
 
           core_sockets[edge_id]?.try(&.close) rescue nil

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -54,9 +54,8 @@ module PlaceOS::Api
     end
 
     def update
-      edge = current_edge
-      edge.assign_attributes_from_json(self.body)
-      save_and_respond edge
+      current_edge.assign_attributes_from_json(self.body)
+      save_and_respond current_edge
     end
 
     # TODO: replace manual id with interpolated value from `id_param`

--- a/src/placeos-rest-api/controllers/metadata.cr
+++ b/src/placeos-rest-api/controllers/metadata.cr
@@ -11,6 +11,8 @@ module PlaceOS::Api
 
     before_action :current_zone, only: :children
 
+    before_action :body, only: [:update, :update_alt]
+
     # Allow unscoped read access to metadata
     skip_action :check_oauth_scope, only: [:show, :children_metadata]
 
@@ -66,7 +68,7 @@ module PlaceOS::Api
     # ameba:disable Metrics/CyclomaticComplexity
     def update
       parent_id = params["id"]
-      metadata = Model::Metadata::Interface.from_json(request.body.as(IO))
+      metadata = Model::Metadata::Interface.from_json(self.body)
 
       # We need a name to lookup the metadata
       head :bad_request if metadata.name.empty?

--- a/src/placeos-rest-api/controllers/modules.cr
+++ b/src/placeos-rest-api/controllers/modules.cr
@@ -219,7 +219,7 @@ module PlaceOS::Api
         module_id: id,
         sys_id: sys_id,
         module_name: module_name,
-        discovery: Systems.core_discovery,
+        discovery: self.class.core_discovery,
       )
 
       result = remote_driver.exec(

--- a/src/placeos-rest-api/controllers/oauth_applications.cr
+++ b/src/placeos-rest-api/controllers/oauth_applications.cr
@@ -8,6 +8,7 @@ module PlaceOS::Api
     before_action :check_support, only: [:index, :show]
 
     before_action :current_app, only: [:show, :update, :update_alt, :destroy]
+    before_action :body, only: [:create, :update, :update_alt]
 
     getter current_app : Model::DoorkeeperApplication { find_app }
 
@@ -31,16 +32,15 @@ module PlaceOS::Api
     end
 
     def update
-      app = current_app
-      app.assign_attributes_from_json(request.body.as(IO))
-      save_and_respond app
+      current_app.assign_attributes_from_json(self.body)
+      save_and_respond current_app
     end
 
     # TODO: replace manual id with interpolated value from `id_param`
     put "/:id", :update_alt { update }
 
     def create
-      save_and_respond(Model::DoorkeeperApplication.from_json(request.body.as(IO)))
+      save_and_respond(Model::DoorkeeperApplication.from_json(self.body))
     end
 
     def destroy

--- a/src/placeos-rest-api/controllers/repositories.cr
+++ b/src/placeos-rest-api/controllers/repositories.cr
@@ -29,7 +29,7 @@ module PlaceOS::Api
       repo.assign_attributes_from_json(request.body.as(IO))
 
       # Must destroy and re-add to change driver repository URIs
-      if repo.uri_changed? && repo.repo_type != Model::Repository::Type::Interface
+      if repo.uri_changed? && repo.repo_type.driver?
         render :unprocessable_entity, text: "Error: uri must not change"
       end
 
@@ -63,7 +63,7 @@ module PlaceOS::Api
     end
 
     def self.pull_repository(repository : Model::Repository)
-      if repository.repo_type == Model::Repository::Type::Driver
+      if repository.repo_type.driver?
         # Set the repository commit hash to head
         repository.update_fields(commit_hash: "HEAD")
 

--- a/src/placeos-rest-api/controllers/repositories.cr
+++ b/src/placeos-rest-api/controllers/repositories.cr
@@ -111,13 +111,13 @@ module PlaceOS::Api
     end
 
     get "/:id/drivers", :drivers do
-      repository = current_repo.folder_name
+      repository_folder = current_repo.folder_name
 
       # Request to core:
       # "/api/core/v1/drivers/?repository=#{repository}"
       # Returns: `["path/to/file.cr"]`
-      drivers = Api::Systems.core_for(repository, request_id) do |core_client|
-        core_client.drivers(repository)
+      drivers = Api::Systems.core_for(repository_folder, request_id) do |core_client|
+        core_client.drivers(repository_folder)
       end
 
       render json: drivers

--- a/src/placeos-rest-api/controllers/system-triggers.cr
+++ b/src/placeos-rest-api/controllers/system-triggers.cr
@@ -82,12 +82,11 @@ module PlaceOS::Api
     def update
       args = UpdateParams.from_json(self.body)
 
-      sys_trig = current_sys_trig
-      sys_trig.enabled = args.enabled.as(Bool) unless args.enabled.nil?
-      sys_trig.important = args.important.as(Bool) unless args.important.nil?
-      sys_trig.exec_enabled = args.exec_enabled.as(Bool) unless args.exec_enabled.nil?
+      current_sys_trig.enabled = args.enabled.as(Bool) unless args.enabled.nil?
+      current_sys_trig.important = args.important.as(Bool) unless args.important.nil?
+      current_sys_trig.exec_enabled = args.exec_enabled.as(Bool) unless args.exec_enabled.nil?
 
-      save_and_respond(sys_trig)
+      save_and_respond(current_sys_trig)
     end
 
     # TODO: replace manual id with interpolated value from `id_param`

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -35,9 +35,6 @@ module PlaceOS::Api
     # Websocket API session manager
     class_getter session_manager : Session::Manager { Session::Manager.new(core_discovery) }
 
-    # Core service discovery
-    class_getter core_discovery = HoundDog::Discovery.new(CORE_NAMESPACE)
-
     # Strong params for index method
     class IndexParams < Params
       attribute bookable : Bool?
@@ -418,7 +415,7 @@ module PlaceOS::Api
 
     # Use consistent hashing to determine the location of the module
     def self.locate_module(module_id : String) : URI
-      node = @@core_discovery.find?(module_id)
+      node = core_discovery.find?(module_id)
       raise "no core instances registered!" unless node
       node[:uri]
     end

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -293,7 +293,7 @@ module PlaceOS::Api
         sys_id: sys_id,
         module_name: module_name,
         index: index,
-        discovery: Systems.core_discovery
+        discovery: self.class.core_discovery
       )
 
       ret_val = remote_driver.exec(

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -26,6 +26,7 @@ module PlaceOS::Api
                                                   :start, :stop, :execute, :types, :functions]
 
     before_action :ensure_json, only: [:create, :update, :update_alt, :execute]
+    before_action :body, only: [:create, :execute, :update, :update_alt]
 
     # Allow unscoped access to details of a single `ControlSystem`
     skip_action :check_oauth_scope, only: [:show, :sys_zones]
@@ -165,7 +166,7 @@ module PlaceOS::Api
         end
       end
 
-      control_system.assign_attributes_from_json(request.body.as(IO))
+      control_system.assign_attributes_from_json(self.body)
       control_system.version = version + 1
 
       save_and_respond(control_system)
@@ -175,7 +176,7 @@ module PlaceOS::Api
     put "/:sys_id", :update_alt { update }
 
     def create
-      save_and_respond Model::ControlSystem.from_json(request.body.as(IO))
+      save_and_respond Model::ControlSystem.from_json(self.body)
     end
 
     def destroy
@@ -287,7 +288,7 @@ module PlaceOS::Api
     post("/:sys_id/:module_slug/:method", :execute) do
       sys_id, module_slug, method = params["sys_id"], params["module_slug"], params["method"]
       module_name, index = RemoteDriver.get_parts(module_slug)
-      args = Array(JSON::Any).from_json(request.body.as(IO))
+      args = Array(JSON::Any).from_json(self.body)
 
       remote_driver = RemoteDriver.new(
         sys_id: sys_id,

--- a/src/placeos-rest-api/controllers/triggers.cr
+++ b/src/placeos-rest-api/controllers/triggers.cr
@@ -7,8 +7,9 @@ module PlaceOS::Api
     before_action :check_admin, only: [:create, :update, :destroy]
     before_action :check_support, only: [:index, :show]
 
-    before_action :ensure_json, only: [:create, :update, :update_alt]
     before_action :current_trigger, only: [:show, :update, :update_alt, :destroy]
+    before_action :ensure_json, only: [:create, :update, :update_alt]
+    before_action :body, only: [:create, :update, :update_alt]
 
     getter current_trigger : Model::Trigger { find_trigger }
 
@@ -33,7 +34,7 @@ module PlaceOS::Api
 
     def update
       trig = current_trigger
-      trig.assign_attributes_from_json(request.body.as(IO))
+      trig.assign_attributes_from_json(self.body)
       save_and_respond(trig)
     end
 
@@ -41,7 +42,7 @@ module PlaceOS::Api
     put "/:id", :update_alt { update }
 
     def create
-      save_and_respond Model::Trigger.from_json(request.body.as(IO))
+      save_and_respond Model::Trigger.from_json(self.body)
     end
 
     def destroy

--- a/src/placeos-rest-api/controllers/triggers.cr
+++ b/src/placeos-rest-api/controllers/triggers.cr
@@ -22,20 +22,15 @@ module PlaceOS::Api
     end
 
     def show
-      trigger = current_trigger
-      if params["instances"]? == "true"
-        render json: with_fields(trigger, {
-          :trigger_instances => trigger.trigger_instances.to_a,
-        })
-      else
-        render json: trigger
-      end
+      include_instances = params["instances"]? == "true"
+      render json: !include_instances ? current_trigger : with_fields(current_trigger, {
+        :trigger_instances => current_trigger.trigger_instances.to_a,
+      })
     end
 
     def update
-      trig = current_trigger
-      trig.assign_attributes_from_json(self.body)
-      save_and_respond(trig)
+      current_trigger.assign_attributes_from_json(self.body)
+      save_and_respond(current_trigger)
     end
 
     # TODO: replace manual id with interpolated value from `id_param`

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -51,19 +51,19 @@ module PlaceOS::Api
       head :not_found unless current_user.refresh_token.presence
 
       begin
-        internals = current_authority.not_nil!.internals.not_nil!
+        internals = current_authority.not_nil!.internals
         sso_strat_id = internals["oauth-strategy"].as_s # (i.e. oauth_strat-FNsaSj6bp-M)
         render(:not_found, text: "no oauth configuration specified in authority") unless sso_strat_id.presence
 
-        sso_strat = ::PlaceOS::Model::OAuthAuthentication.find!(sso_strat_id.not_nil!)
-        client_id = sso_strat.client_id.not_nil!
-        client_secret = sso_strat.client_secret.not_nil!
-        token_uri = URI.parse(sso_strat.token_url.not_nil!)
+        sso_strat = ::PlaceOS::Model::OAuthAuthentication.find!(sso_strat_id)
+        client_id = sso_strat.client_id
+        client_secret = sso_strat.client_secret
+        token_uri = URI.parse(sso_strat.token_url)
         token_host = token_uri.host.not_nil!
         token_path = token_uri.full_path
 
         oauth2_client = OAuth2::Client.new(token_host, client_id, client_secret, token_uri: token_path)
-        token = oauth2_client.get_access_token_using_refresh_token(current_user.refresh_token.not_nil!, sso_strat.scope)
+        token = oauth2_client.get_access_token_using_refresh_token(current_user.refresh_token, sso_strat.scope)
 
         current_user.access_token = token.access_token
         current_user.refresh_token = token.refresh_token if token.refresh_token

--- a/src/placeos-rest-api/controllers/zones.cr
+++ b/src/placeos-rest-api/controllers/zones.cr
@@ -88,10 +88,12 @@ module PlaceOS::Api
       render json: triggers
     end
 
-    record ZoneExecResponse,
+    record(
+      ZoneExecResponse,
       success : Array(String) = [] of String,
       failure : Array(String) = [] of String,
-      module_missing : Array(String) = [] of String { include JSON::Serializable }
+      module_missing : Array(String) = [] of String
+    ) { include JSON::Serializable }
 
     # Execute a method on a module across all systems in a Zone
     post "/:id/exec/:module_slug/:method", :zone_execute do

--- a/src/placeos-rest-api/error.cr
+++ b/src/placeos-rest-api/error.cr
@@ -12,6 +12,9 @@ module PlaceOS::Api
     class Forbidden < Error
     end
 
+    class NoBody < Error
+    end
+
     class InvalidParams < Error
       getter params
 

--- a/src/placeos-rest-api/session.cr
+++ b/src/placeos-rest-api/session.cr
@@ -383,7 +383,7 @@ module PlaceOS
             ))
         end
 
-        spawn ws.run
+        spawn(same_thread: true) { ws.run }
         debug_sessions[{sys_id, module_name, index}] = ws
       end
 

--- a/src/placeos-rest-api/session.cr
+++ b/src/placeos-rest-api/session.cr
@@ -216,7 +216,7 @@ module PlaceOS
         sys_id: sys_id,
         module_name: module_name,
         index: index,
-        discovery: Systems.core_discovery
+        discovery: @discovery
       )
 
       response = driver.exec(@security_level, name, args, request_id: @request_id)
@@ -360,7 +360,7 @@ module PlaceOS
           module_id: module_name,
           sys_id: sys_id,
           module_name: module_name,
-          discovery: Systems.core_discovery
+          discovery: @discovery
         )
 
         ws = driver.debug

--- a/src/placeos-rest-api/utilities/core_discovery.cr
+++ b/src/placeos-rest-api/utilities/core_discovery.cr
@@ -1,0 +1,21 @@
+require "hound-dog"
+
+module PlaceOS::Api
+  class Discovery::Core < HoundDog::Discovery
+    class_getter instance : Discovery::Core do
+      new(service: CORE_NAMESPACE)
+    end
+
+    def initialize(**args)
+      super **args
+
+      @on_change = ->on_change(Array(HoundDog::Service::Node))
+    end
+
+    getter callbacks = [] of Array(HoundDog::Service::Node) ->
+
+    def on_change(changes : Array(HoundDog::Service::Node))
+      callbacks.each &.call changes
+    end
+  end
+end


### PR DESCRIPTION
Implements the edge to core proxy with retries and disconnection logic.

Closes #77 

## Routes

- `WS   /api/engine/v2/edges?token=${token}`: proxies a `edge` node to a `core`
- `GET /api/engine/v2/edges/:edge_id/token`: returns `{"token": "#{edge_id}_s0m3s3cr3t"}`
- Standard CRUD interface to [PlaceOS::Model::Edge](https://github.com/PlaceOS/models/blob/master/src/placeos-models/edge.cr)

## Sundries

- Safe request body IO accessor. Returns 400 if expected body not present.
- Singleton `core` discovery attached to abstract application controller