### PR TITLE
fix(controller:oauth_applications): restrict to admin

### DIFF
--- a/src/placeos-rest-api/controllers/oauth_applications.cr
+++ b/src/placeos-rest-api/controllers/oauth_applications.cr
@@ -4,9 +4,7 @@ module PlaceOS::Api
   class OAuthApplications < Application
     base "/api/engine/v2/oauth_apps/"
 
-    before_action :check_admin, except: [:index, :show]
-    before_action :check_support, only: [:index, :show]
-
+    before_action :check_admin
     before_action :current_app, only: [:show, :update, :update_alt, :destroy]
 
     getter current_app : Model::DoorkeeperApplication { find_app }


### PR DESCRIPTION
Restrict OAuth applications endpoint to admin users.

Fixes #84 