### PR TITLE
fix: build action

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -12,7 +12,7 @@ jobs:
       name: Extract names
       run: |
         echo ::set-output name=image::$(echo ${GITHUB_REPOSITORY,,})
-        echo ::set-output name=tag::$(echo ${GITHUB_REF#refs/heads/})
+        echo ::set-output name=tag::$(echo ${GITHUB_REF#refs/heads/} | sed 's/[^[:alnum:]\.\_\-]/-/g')
       id: name
     -
       name: Set up QEMU


### PR DESCRIPTION
Filter invalid chars in branch name when generating image tag.