### PR TITLE
feat: user group query

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -134,7 +134,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 4.9.0
+    version: 4.10.0
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-rest-api
-version: 1.18.3
+version: 1.19.0
 
 targets:
   rest-api:

--- a/spec/root_spec.cr
+++ b/spec/root_spec.cr
@@ -55,7 +55,7 @@ module PlaceOS::Api
 
         it "validates presence of `channel` param" do
           result = curl("POST", File.join(base, "signal"), body: "hello", headers: authorization_header)
-          result.status_code.should eq 422
+          result.status_code.should eq 400
         end
 
         it "prevents access to non-guest channels for guests" do

--- a/src/placeos-rest-api/controllers/application.cr
+++ b/src/placeos-rest-api/controllers/application.cr
@@ -164,11 +164,11 @@ module PlaceOS::Api
       head :not_found
     end
 
-    # 422 if resource fails validation before mutation
+    # 400 if params fails validation before mutation
     rescue_from Error::InvalidParams do |error|
       model_errors = error.params.errors.map(&.to_s)
       Log.debug(exception: error) { {message: "invalid params", model_errors: model_errors} }
-      render status: :unprocessable_entity, json: model_errors
+      render status: :bad_request, json: model_errors
     end
   end
 end

--- a/src/placeos-rest-api/controllers/modules.cr
+++ b/src/placeos-rest-api/controllers/modules.cr
@@ -141,15 +141,11 @@ module PlaceOS::Api
     def update
       current_module.assign_attributes_from_json(self.body)
 
-      if current_module.save
-        driver = current_module.driver
-        serialised = !driver ? current_module : with_fields(current_module, {
+      save_and_respond(current_module) do |mod|
+        driver = mod.driver
+        !driver ? mod : with_fields(mod, {
           :driver => restrict_attributes(driver, only: DRIVER_ATTRIBUTES),
         })
-
-        render json: serialised
-      else
-        render status: :unprocessable_entity, json: current_module.errors.map(&.to_s)
       end
     end
 

--- a/src/placeos-rest-api/controllers/settings.cr
+++ b/src/placeos-rest-api/controllers/settings.cr
@@ -37,11 +37,7 @@ module PlaceOS::Api
     def update
       current_settings.assign_attributes_from_json(self.body)
 
-      if current_settings.save
-        render json: current_settings.decrypt_for!(current_user)
-      else
-        render json: current_settings.errors.map(&.to_s), status: :unprocessable_entity
-      end
+      save_and_respond(current_settings, &.decrypt_for!(current_user))
     end
 
     # TODO: replace manual id with interpolated value from `id_param`
@@ -49,11 +45,7 @@ module PlaceOS::Api
 
     def create
       new_settings = Model::Settings.from_json(self.body)
-      if new_settings.save
-        render json: new_settings.decrypt_for!(current_user), status: :created
-      else
-        render json: new_settings.errors.map(&.to_s), status: :unprocessable_entity
-      end
+      save_and_respond(new_settings, &.decrypt_for!(current_user))
     end
 
     def destroy

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -150,7 +150,7 @@ module PlaceOS::Api
       emails_param = params["emails"]?.presence
       if emails_param.nil?
         error = "missing `emails` param"
-        render status: :unprocessable_entity, json: {error: error}, text: error
+        render status: :bad_request, json: {error: error}, text: error
       end
 
       emails = emails_param.split(',')

--- a/src/placeos-rest-api/utilities/responders.cr
+++ b/src/placeos-rest-api/utilities/responders.cr
@@ -1,11 +1,24 @@
 require "http"
+require "placeos-models"
 
 module PlaceOS::Api
   module Utils::Responders
     # Shortcut to save a record and render a response
+    #
+    # Accepts an optional block to process the entity before response.
     def save_and_respond(resource)
       result, status = save_and_status(resource)
+
+      if status.ok? && result.is_a?(PlaceOS::Model::ModelBase)
+        result = yield result
+      end
+
       render json: result, status: status
+    end
+
+    # :ditto:
+    def save_and_respond(resource)
+      save_and_respond(resource) { resource }
     end
 
     # Shortcut to save a record and give the correct status


### PR DESCRIPTION
- Add `/users/groups?emails=<emails>` for querying users' groups by email
- Missing parameters yield HTTP status `400` instead of `422`
- Refactor `save_and_respond` to accept a block to mutate a successfully saved entity