### PR TITLE
style: fix a suite of ameba lints

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,0 +1,12 @@
+Style/VerboseBlock:
+  Description: Identifies usage of collapsible single expression blocks.
+  ExcludeCallsWithBlock: true
+  ExcludeMultipleLineBlocks: false
+  ExcludePrefixOperators: true
+  ExcludeOperators: false
+  ExcludeSetters: false
+  MaxLength: 50
+  Excluded:
+  - spec/*
+  Enabled: true
+  Severity: Convention

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -28,9 +28,7 @@ require "spec"
 # Configure DB
 db_name = "place_#{ENV["SG_ENV"]? || "development"}"
 
-RethinkORM.configure do |settings|
-  settings.db = db_name
-end
+RethinkORM.configure &.db=(db_name)
 
 Spec.after_suite { clear_tables }
 

--- a/spec/modules_spec.cr
+++ b/spec/modules_spec.cr
@@ -228,7 +228,7 @@ module PlaceOS::Api
         result.success?.should be_true
 
         settings = Array(Hash(String, JSON::Any)).from_json(result.body)
-        settings_hierarchy_ids = settings.map { |s| s["id"].to_s }
+        settings_hierarchy_ids = settings.map &.["id"].to_s
 
         settings_hierarchy_ids.should eq expected_settings_ids
         {mod, control_system, zone, driver}.each &.destroy

--- a/spec/systems_spec.cr
+++ b/spec/systems_spec.cr
@@ -162,7 +162,7 @@ module PlaceOS::Api
           result.status_code.should eq 200
           documents = Array(Hash(String, JSON::Any)).from_json(result.body)
           documents.size.should eq 2
-          documents.map { |d| d["id"].as_s }.sort.should eq [zone0.id, zone1.id].compact.sort
+          documents.map(&.["id"].as_s).sort!.should eq [zone0.id, zone1.id].compact.sort!
         end
       end
 

--- a/spec/triggers_spec.cr
+++ b/spec/triggers_spec.cr
@@ -28,7 +28,7 @@ module PlaceOS::Api
           result = Array(JSON::Any).from_json(response.body).map { |d| Model::TriggerInstance.from_trusted_json(d.to_json) }
 
           result.all? { |i| i.trigger_id == trigger.id }.should be_true
-          instances.compact_map(&.id).sort.should eq result.compact_map(&.id).sort
+          instances.compact_map(&.id).sort!.should eq result.compact_map(&.id).sort!
         end
       end
 

--- a/src/placeos-rest-api/controllers/application.cr
+++ b/src/placeos-rest-api/controllers/application.cr
@@ -36,7 +36,7 @@ module PlaceOS::Api
       if range_end < total_items
         params["offset"] = (range_end + 1).to_s
         params["limit"] = query.limit.to_s
-        query_params = params.map { |key, value| "#{key}=#{value}" }.join("&")
+        query_params = params.join('&') { |key, value| "#{key}=#{value}" }
         response.headers["Link"] = %(<#{route}?#{query_params}>; rel="next")
       end
 

--- a/src/placeos-rest-api/controllers/cluster.cr
+++ b/src/placeos-rest-api/controllers/cluster.cr
@@ -158,7 +158,7 @@ module PlaceOS::Api
       driver = params["driver"]
 
       uri = self.class.core_discovery.node_hash[core_id]
-      if Core::Client.client(uri, request_id) { |client| client.terminate(driver) }
+      if Core::Client.client(uri, request_id, &.terminate(driver))
         head :ok
       else
         head :not_found

--- a/src/placeos-rest-api/controllers/metadata.cr
+++ b/src/placeos-rest-api/controllers/metadata.cr
@@ -53,7 +53,7 @@ module PlaceOS::Api
                        end
 
       children = current_zone.children.all
-      filtered = include_parent ? children : children.reject { |z| z.id == parent_id }
+      filtered = include_parent ? children : children.reject &.id.==(parent_id)
 
       results = filtered.map do |zone|
         {

--- a/src/placeos-rest-api/controllers/modules.cr
+++ b/src/placeos-rest-api/controllers/modules.cr
@@ -260,11 +260,7 @@ module PlaceOS::Api
 
     post("/:id/load", :load) do
       module_id = params["id"]
-      load = Api::Systems.core_for(module_id, request_id) do |core_client|
-        core_client.load(module_id)
-      end
-
-      render json: load
+      render json: Api::Systems.core_for(module_id, request_id, &.load(module_id))
     end
 
     # Helpers

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -114,7 +114,7 @@ module PlaceOS::Api
 
     # Finds all the systems with the specified email address
     get "/with_emails", :find_by_email do
-      emails = params["in"].split(',').map(&.strip).reject(&.empty?).uniq
+      emails = params["in"].split(',').map(&.strip).reject(&.empty?).uniq!
       systems = Model::ControlSystem.get_all(emails, index: :email).to_a
       set_collection_headers(systems.size, Model::ControlSystem.table_name)
       render json: systems

--- a/src/placeos-rest-api/controllers/webhook.cr
+++ b/src/placeos-rest-api/controllers/webhook.cr
@@ -83,7 +83,7 @@ module PlaceOS::Api
       head :not_found
     end
 
-    {% for http_method in ActionController::Router::HTTP_METHODS.reject { |verb| verb == "head" } %}
+    {% for http_method in ActionController::Router::HTTP_METHODS.reject &.==("head") %}
       {{http_method.id}} "/:id/notify" do
         return notify({{http_method.id.stringify.upcase}}) if current_trigger.supported_method? {{http_method.id.stringify.upcase}}
         Log.warn { "attempt to notify trigger #{current_trigger_instance.id} with unsupported method #{{{http_method.id.stringify}}}" }

--- a/src/placeos-rest-api/controllers/zones.cr
+++ b/src/placeos-rest-api/controllers/zones.cr
@@ -29,7 +29,7 @@ module PlaceOS::Api
 
       if params.has_key? "tags"
         # list of unique tags
-        tags = params["tags"].gsub(/[^0-9a-z ]/i, "").split(',').reject(&.empty?).uniq
+        tags = params["tags"].gsub(/[^0-9a-z ]/i, "").split(',').reject(&.empty?).uniq!
 
         head :bad_request if tags.empty?
 

--- a/src/placeos-rest-api/session.cr
+++ b/src/placeos-rest-api/session.cr
@@ -577,7 +577,7 @@ module PlaceOS
       @bindings.clear
 
       # Ignore (stop debugging) all modules
-      debug_sessions.each_value { |socket| socket.close }
+      debug_sessions.each_value &.close
       debug_sessions.clear
     end
 


### PR DESCRIPTION
Fixes a bunch of lints introduced by the latest ameba version.
Includes a `.ameba.yml` that ignores the short block lint in specs.