### PR TITLE
fix(controller:cluster): empty array on key miss

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-rest-api
-version: 1.20.0
+version: 1.21.0
 crystal: ~> 0.35
 
 targets:

--- a/src/placeos-rest-api/controllers/cluster.cr
+++ b/src/placeos-rest-api/controllers/cluster.cr
@@ -137,7 +137,7 @@ module PlaceOS::Api
       edges = edge_modules.map do |edge_id, processes|
         {
           edge_id, {
-            modules: processes[key],
+            modules: processes[key]? || [] of String,
             status:  status.try(&.edge[edge_id]?),
           }.as(Driver),
         }
@@ -146,7 +146,7 @@ module PlaceOS::Api
       {
         driver: key,
         local:  {
-          modules: local_modules[key],
+          modules: local_modules[key]? || [] of String,
           status:  status.try(&.local),
         }.as(Driver),
         edge: edges,


### PR DESCRIPTION
Don't throw on the missing driver key in cluster status route