### PR TITLE
refactor(controller:cluster): use `id` instead of `core_id`

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,6 +12,7 @@ RUN update-ca-certificates
 
 RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing watchexec
 
+COPY .ameba.yml /app
 COPY shard.yml /app
 COPY shard.override.yml /app
 COPY shard.lock /app

--- a/shard.lock
+++ b/shard.lock
@@ -7,7 +7,7 @@ shards:
 
   action-controller:
     git: https://github.com/spider-gazelle/action-controller.git
-    version: 4.1.0
+    version: 4.2.0
 
   active-model:
     git: https://github.com/spider-gazelle/active-model.git
@@ -15,7 +15,7 @@ shards:
 
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 0.13.4
+    version: 0.14.0
 
   bindata:
     git: https://github.com/spider-gazelle/bindata.git
@@ -123,15 +123,19 @@ shards:
 
   placeos-core:
     git: https://github.com/placeos/core.git
-    version: 3.2.0
+    version: 3.3.0
 
   placeos-driver:
     git: https://github.com/placeos/driver.git
-    version: 4.2.0
+    version: 4.3.0
 
   placeos-frontends:
     git: https://github.com/placeos/frontends.git
     version: 0.10.9
+
+  placeos-log-backend:
+    git: https://github.com/place-labs/log-backend.git
+    version: 0.1.0
 
   placeos-models:
     git: https://github.com/placeos/models.git
@@ -139,7 +143,7 @@ shards:
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git
-    version: 1.0.5
+    version: 1.0.6
 
   pool:
     git: https://github.com/ysbaddaden/pool.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-rest-api
-version: 1.21.0
+version: 1.22.0
 crystal: ~> 0.35
 
 targets:
@@ -21,6 +21,11 @@ dependencies:
   CrystalEmail:
     github: Nephos/CrystalEmail
     version: ~> 0.2
+
+  # Pin on the etcd lib
+  etcd:
+    github: place-labs/crystal-etcd
+    version: ~> 1.0.0
 
   # Service discovery
   hound-dog:

--- a/src/placeos-rest-api/controllers/cluster.cr
+++ b/src/placeos-rest-api/controllers/cluster.cr
@@ -36,7 +36,7 @@ module PlaceOS::Api
     end
 
     alias NodeStatus = NamedTuple(
-      core_id: String,
+      id: String,
       uri: URI,
       # Get the cluster load
       load: PlaceOS::Core::Client::Load?,
@@ -47,8 +47,8 @@ module PlaceOS::Api
     def self.node_status(core_id : String, uri : URI, request_id : String) : NodeStatus?
       Core::Client.client(uri, request_id) do |client|
         {
-          core_id: core_id,
-          uri:     uri,
+          id:  core_id,
+          uri: uri,
           # Get the cluster load
           load: client.core_load,
           # Get the cluster details (number of drivers running, errors etc)


### PR DESCRIPTION
Use `id` instead of `core_id` in responses from `../cluster`