### PR TITLE
refactor: consolidate error responses

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -67,7 +67,7 @@ shards:
 
   habitat:
     git: https://github.com/luckyframework/habitat.git
-    version: 0.4.5
+    version: 0.4.6
 
   hardware:
     git: https://github.com/crystal-community/hardware.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-rest-api
-version: 1.22.0
+version: 1.23.0
 crystal: ~> 0.35
 
 targets:

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -1,0 +1,19 @@
+module PlaceOS::Api
+  APP_NAME    = "rest-api"
+  API_VERSION = "v2"
+
+  # Calculate version, build time, commit at compile time
+  VERSION      = {{ system(%(shards version "#{__DIR__}")).chomp.stringify.downcase }}
+  BUILD_TIME   = {{ system("date -u").stringify }}
+  BUILD_COMMIT = {{ env("PLACE_COMMIT") || "DEV" }}
+
+  CORE_NAMESPACE = "core"
+
+  ETCD_HOST = ENV["ETCD_HOST"]? || "localhost"
+  ETCD_PORT = (ENV["ETCD_PORT"]? || "2379").to_i
+
+  # server defaults in `./app.cr`
+  TRIGGERS_URI = URI.parse(ENV["TRIGGERS_URI"]? || "http://triggers:3000")
+
+  PROD = ENV["SG_ENV"]?.try(&.downcase) == "production"
+end

--- a/src/placeos-rest-api.cr
+++ b/src/placeos-rest-api.cr
@@ -3,27 +3,12 @@ require "log_helper"
 require "placeos-log-backend"
 require "secrets-env"
 
+require "./constants"
 require "./placeos-rest-api/controllers/application"
 require "./placeos-rest-api/controllers/*"
 
 module PlaceOS::Api
-  APP_NAME    = "rest-api"
-  API_VERSION = "v2"
-  # Calculate version, build time, commit at compile time
-  VERSION        = {{ system(%(shards version "#{__DIR__}")).chomp.stringify.downcase }}
-  BUILD_TIME     = {{ system("date -u").stringify }}
-  BUILD_COMMIT   = {{ env("PLACE_COMMIT") || "DEV" }}
-  CORE_NAMESPACE = "core"
-
   Log = ::Log.for(APP_NAME)
-
-  ETCD_HOST = ENV["ETCD_HOST"]? || "localhost"
-  ETCD_PORT = (ENV["ETCD_PORT"]? || "2379").to_i
-
-  # server defaults in `./app.cr`
-  TRIGGERS_URI = URI.parse(ENV["TRIGGERS_URI"]? || "http://triggers:3000")
-
-  PROD = ENV["SG_ENV"]? == "production"
 
   class_getter? production : Bool = PROD
 end

--- a/src/placeos-rest-api/controllers/drivers.cr
+++ b/src/placeos-rest-api/controllers/drivers.cr
@@ -16,7 +16,7 @@ module PlaceOS::Api
       # Pick off role from HTTP params, render error if present and invalid
       role = params["role"]?.try &.to_i?.try do |r|
         parsed = Model::Driver::Role.from_value?(r)
-        render status: :unprocessable_entity, text: "Invalid Role" unless parsed
+        return render_error(HTTP::Status::UNPROCESSABLE_ENTITY, "Invalid `role`") if parsed.nil?
         parsed
       end
 
@@ -48,7 +48,7 @@ module PlaceOS::Api
       current_driver.assign_attributes_from_json(self.body)
 
       # Must destroy and re-add to change driver type
-      render :unprocessable_entity, text: "Error: role must not change" if current_driver.role_changed?
+      return render_error(HTTP::Status::UNPROCESSABLE_ENTITY, "Driver role must not change") if current_driver.role_changed?
 
       save_and_respond current_driver
     end

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -27,9 +27,10 @@ module PlaceOS::Api
     ws("/control", :edge) do |socket|
       token = params["token"]?
 
-      render status: :bad_request, json: {error: "missing 'token' param"} if token.nil? || token.presence.nil?
+      return render_error(HTTP::Status::BAD_REQUEST, "Missing 'token' param") if token.nil? || token.presence.nil?
 
       edge_id = Model::Edge.validate_token?(token)
+
       head status: :unauthorized if edge_id.nil?
 
       Log.info { {edge_id: edge_id, message: "new edge connection"} }

--- a/src/placeos-rest-api/controllers/modules.cr
+++ b/src/placeos-rest-api/controllers/modules.cr
@@ -229,7 +229,12 @@ module PlaceOS::Api
         module_name: current_module.name,
         method:      method,
       } }
-      render text: "#{e.message}\n#{e.inspect_with_backtrace}", status: :internal_server_error
+
+      if Api.production?
+        render_error(HTTP::Status::INTERNAL_SERVER_ERROR, e.message)
+      else
+        render_error(HTTP::Status::INTERNAL_SERVER_ERROR, e.message, backtrace: e.backtrace?)
+      end
     end
 
     # Dumps the complete status state of the module

--- a/src/placeos-rest-api/controllers/repositories.cr
+++ b/src/placeos-rest-api/controllers/repositories.cr
@@ -30,7 +30,7 @@ module PlaceOS::Api
 
       # Must destroy and re-add to change driver repository URIs
       if current_repo.uri_changed? && current_repo.repo_type.driver?
-        render :unprocessable_entity, json: {error: "uri must not change"}, text: "uri must not change"
+        return render_error(HTTP::Status::UNPROCESSABLE_ENTITY, "`uri` of Driver repositories cannot change")
       end
 
       save_and_respond current_repo
@@ -58,7 +58,7 @@ module PlaceOS::Api
           render json: {commit_hash: commit_hash}
         end
       else
-        head :request_timeout
+        return render_error(HTTP::Status::REQUEST_TIMEOUT, "Pull timed out")
       end
     end
 

--- a/src/placeos-rest-api/controllers/system-triggers.cr
+++ b/src/placeos-rest-api/controllers/system-triggers.cr
@@ -96,7 +96,7 @@ module PlaceOS::Api
       model = Model::TriggerInstance.from_json(self.body)
 
       if model.control_system_id != current_system.id
-        render status: :unprocessable_entity, json: {error: "control_system_id mismatch"}, text: "control_system_id mismatch"
+        render_error(HTTP::Status::UNPROCESSABLE_ENTITY, "control_system_id mismatch")
       else
         save_and_respond model
       end

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -141,23 +141,16 @@ module PlaceOS::Api
 
     # Updates a control system
     def update
-      version = begin
-        args = UpdateParams.new(params).validate!
-        args.version
-      rescue
-        message = "missing system version parameter"
-        respond_with(:precondition_failed) do
-          text message
-          json({error: message})
-        end
+      args = UpdateParams.new(params)
+
+      unless args.valid?
+        return render_error(HTTP::Status::PRECONDITION_FAILED, "Missing System version parameter")
       end
 
+      version = args.version
+
       if version != current_control_system.version
-        message = "attempting to edit an old version"
-        respond_with(:conflict) do
-          text message
-          json({error: message})
-        end
+        return render_error(HTTP::Status::CONFLICT, "Attempting to edit an old System version")
       end
 
       current_control_system.assign_attributes_from_json(self.body)

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -148,17 +148,12 @@ module PlaceOS::Api
     # - `[{id: "<user-id>", groups: ["<group>"]}]`
     get("/groups") do
       emails_param = params["emails"]?.presence
-      if emails_param.nil?
-        error = "missing `emails` param"
-        render status: :bad_request, json: {error: error}, text: error
-      end
+      return render_error(HTTP::Status::BAD_REQUEST, "Missing `emails` param") if emails_param.nil?
 
       emails = emails_param.split(',')
       errors = self.class.validate_emails(emails)
 
-      unless errors.empty?
-        render status: :unprocessable_entity, json: {error: errors}, text: errors.join(',')
-      end
+      return render_error(HTTP::Status::UNPROCESSABLE_ENTITY, errors.join(", ")) unless errors.empty?
 
       render json: Model::User.find_by_emails(authority_id: current_user.authority_id.as(String), emails: emails).to_a
     end

--- a/src/placeos-rest-api/utilities/responders.cr
+++ b/src/placeos-rest-api/utilities/responders.cr
@@ -3,6 +3,13 @@ require "placeos-models"
 
 module PlaceOS::Api
   module Utils::Responders
+    # Renders API error messages in a consistent format
+    #
+    def render_error(status : HTTP::Status, message : String?, **additional)
+      message = "API error" if message.nil?
+      render status: status, json: additional.merge({message: message})
+    end
+
     # Shortcut to save a record and render a response
     #
     # Accepts an optional block to process the entity before response.


### PR DESCRIPTION
- Moves constants to a separate file.
- Consolidates the error responses to the format `{"message": "<text>"}`, as well as merging additional arguments to the response object.

The responder logic is independent of an error. Perhaps it could do with a better name than `render_error`?