### PR TITLE
Provide client errors for invalid repository requests

### DIFF
--- a/spec/repositories_spec.cr
+++ b/spec/repositories_spec.cr
@@ -68,6 +68,36 @@ module PlaceOS::Api
             result.status_code.should eq 200
           end
         end
+
+        describe "driver only actions" do
+          it "errors if enumerating drivers in an interface repo" do
+            repository = Model::Generator.repository(type: Model::Repository::Type::Interface).save!
+
+            id = repository.id.as(String)
+            path = "#{base}#{id}/drivers"
+            result = curl(
+              method: "GET",
+              path: path,
+              headers: authorization_header.merge({"Content-Type" => "application/json"}),
+            )
+
+            result.status.should eq HTTP::Status::BAD_REQUEST
+          end
+
+          it "errors when requesting driver details from an interface repo" do
+            repository = Model::Generator.repository(type: Model::Repository::Type::Interface).save!
+
+            id = repository.id.as(String)
+            path = "#{base}#{id}/details"
+            result = curl(
+              method: "GET",
+              path: path,
+              headers: authorization_header.merge({"Content-Type" => "application/json"}),
+            )
+
+            result.status.should eq HTTP::Status::BAD_REQUEST
+          end
+        end
       end
     end
   end

--- a/src/placeos-rest-api/controllers/repositories.cr
+++ b/src/placeos-rest-api/controllers/repositories.cr
@@ -11,8 +11,15 @@ module PlaceOS::Api
 
     before_action :current_repo, only: [:branches, :commits, :destroy, :details, :drivers, :show, :update, :update_alt]
     before_action :body, only: [:create, :update, :update_alt]
+    before_action :drivers_only, only: [:drivers, :details]
 
     getter current_repo : Model::Repository { find_repo }
+
+    private def drivers_only
+      unless current_repo.repo_type.driver?
+        render_error(:bad_request, "not a driver repository")
+      end
+    end
 
     def index
       elastic = Model::Repository.elastic


### PR DESCRIPTION
Returns a HTTP 400 for requests not applicable to the repository type.

Previously this would result in a HTTP 500 following some [undefined behaviour](https://github.com/PlaceOS/PlaceOS/issues/77#issuecomment-843766980).