### PR TITLE
fix: ensure session/session managers caches are shrunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         crystal:
-          - latest
           - nightly
           - 1.0.0
     steps:

--- a/shard.lock
+++ b/shard.lock
@@ -135,7 +135,7 @@ shards:
 
   placeos-driver:
     git: https://github.com/placeos/driver.git
-    version: 5.3.15
+    version: 5.4.4
 
   placeos-frontends:
     git: https://github.com/placeos/frontends.git
@@ -167,7 +167,7 @@ shards:
 
   redis:
     git: https://github.com/stefanwille/crystal-redis.git
-    version: 2.7.0
+    version: 2.8.0
 
   redis-cluster:
     git: https://github.com/caspiano/redis-cluster.cr.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-rest-api
-version: 1.29.0
+version: 1.29.1
 crystal: ~> 1
 
 targets:

--- a/spec/session_spec.cr
+++ b/spec/session_spec.cr
@@ -27,7 +27,7 @@ module PlaceOS::Api
 
               ws.send Session::Request.new(
                 id: rand(10).to_i64,
-                sys_id: control_system.id.as(String),
+                system_id: control_system.id.as(String),
                 module_name: mod.resolved_name,
                 name: status_name,
                 command: Session::Request::Command::Bind,
@@ -67,7 +67,7 @@ module PlaceOS::Api
           results = test_websocket_api(base, authorization_header) do |ws, control_system, mod|
             request = {
               id:          id,
-              sys_id:      control_system.id.as(String),
+              system_id:   control_system.id.as(String),
               module_name: mod.resolved_name,
               name:        status_name,
               command:     Session::Request::Command::Bind,

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -377,7 +377,9 @@ module PlaceOS::Api
     ###########################################################################
 
     ws("/control", :control) do |ws|
-      Log.debug { "WebSocket API request" }
+      Log.trace { "WebSocket API request" }
+      fixed_device = params["fixed_device"]?.try(&.downcase) == "true"
+      Log.context.set(fixed_device: fixed_device)
       Systems.session_manager.create_session(
         ws: ws,
         request_id: request_id,


### PR DESCRIPTION
Crystal arrays don't shrink... so we need to dup long-lived arrays to resize the internal buffers.

This PR does that and...
- adds some synchronization
- refactors how log contexts are set for websocket sessions