### PR TITLE
refactor: use `build` for driver commit listing

### DIFF
--- a/src/placeos-rest-api/controllers/drivers.cr
+++ b/src/placeos-rest-api/controllers/drivers.cr
@@ -86,36 +86,9 @@ module PlaceOS::Api
       driver.update_fields(commit: "RECOMPILE-#{driver.commit}")
 
       # Initiate changefeed on the document's commit
-      changefeed = Model::Driver.changes(driver.id.as(String))
-      channel = Channel(Model::Driver?).new(1)
-
-      # Wait until the commit hash is not head with a timeout of 20 seconds
-      found_driver = begin
-        spawn do
-          update_event = changefeed.find do |event|
-            driver_update = event.value
-            driver_update.destroyed? || !driver_update.commit.starts_with? "RECOMPILE"
-          end
-          channel.send(update_event.try &.value)
-        end
-
-        select
-        when received = channel.receive
-          received
-        when timeout(20.seconds)
-          raise "timeout waiting for recompile"
-        end
-
-        received
-      rescue
-        nil
-      ensure
-        channel.close
-        # Terminate the changefeed
-        changefeed.stop
+      find_change(driver) do |driver_update|
+        driver_update.destroyed? || !driver_update.commit.starts_with? "RECOMPILE"
       end
-
-      found_driver
     end
 
     # Check if the core responsible for the driver has finished compilation

--- a/src/placeos-rest-api/controllers/repositories.cr
+++ b/src/placeos-rest-api/controllers/repositories.cr
@@ -76,33 +76,8 @@ module PlaceOS::Api
       # Trigger a pull event
       repository.pull!
 
-      # Initiate changefeed on the document's commit_hash
-      changefeed = Model::Repository.changes(repository.id.as(String))
-      channel = Channel(Model::Repository?).new(1)
-
-      # Wait until the commit hash is not head with a timeout of 20 seconds
-      found_repo = begin
-        spawn do
-          update_event = changefeed.find do |event|
-            repo = event.value
-            repo.destroyed? || !repo.should_pull?
-          end
-          channel.send(update_event.try &.value)
-        end
-
-        select
-        when received = channel.receive?
-          received
-        when timeout(3.minutes)
-          Log.info { "timeout" }
-          raise "timeout for repository update"
-        end
-      rescue
-        nil
-      ensure
-        # Terminate the changefeed
-        changefeed.stop
-        channel.close
+      found_repo = find_change(repository) do |repo|
+        repo.destroyed? || !repo.should_pull?
       end
 
       unless found_repo.nil?


### PR DESCRIPTION
Use upstream service `build` to fetch repository metadata such as branches and commits