### PR TITLE
Fix failing version spec

### DIFF
--- a/spec/root_spec.cr
+++ b/spec/root_spec.cr
@@ -49,14 +49,14 @@ module PlaceOS::Api
             headers = HTTP::Headers.new
             headers["Content-Type"] = "application/json"
             body = {
-              service: $~["service"],
-              commit: "DEV",
-              version: "v1.0.0",
-              build_time: "Tue Jun 01 01:00:00 UTC 2021",
+              service:          $~["service"],
+              commit:           "DEV",
+              version:          "v1.0.0",
+              build_time:       "Tue Jun 01 01:00:00 UTC 2021",
               platform_version: "DEV",
             }.to_json
             HTTP::Client::Response.new(200, body, headers)
-        end
+          end
 
         # Dispatch currently exposes a non-standard version endpoint
         # https://github.com/PlaceOS/dispatch/issues/6

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -91,8 +91,10 @@ module PlaceOS::Api
         spawn do
           %version = begin
                       {{service.id}}_version
-                    rescue
-                      Log.warn { {service: {{ service }}, message: "failed to request version" }}
+                    rescue e
+                      Log.warn(exception: e) do
+                        {service: {{ service }}, message: "failed to request version" }
+                      end
                       nil
                     end
           version_channel.send(%version)


### PR DESCRIPTION
Adds missing mock endpoints for upstream version queries and expands logging in case of failure.