### PR TITLE
fix: settings support view

### DIFF
--- a/spec/controllers/settings_spec.cr
+++ b/spec/controllers/settings_spec.cr
@@ -7,6 +7,36 @@ module PlaceOS::Api
     with_server do
       test_404(base, model_name: Model::Settings.table_name, headers: authorization_header)
 
+      describe "support user" do
+        context "access" do
+          _, support_header = authentication(sys_admin: false, support: true)
+          sys = Model::Generator.control_system.save!
+          setting = Model::Generator.settings(encryption_level: Encryption::Level::None, control_system: sys)
+          setting.settings_string = "tree: 1"
+          setting.save!
+
+          it "index" do
+            result = curl(
+              method: "GET",
+              path: File.join(base, "?parent_id=#{sys.id}"),
+              headers: support_header,
+            )
+
+            result.status_code.should eq 200
+          end
+
+          it "show" do
+            result = curl(
+              method: "GET",
+              path: File.join(base, setting.id.as(String)),
+              headers: support_header,
+            )
+
+            result.status_code.should eq 200
+          end
+        end
+      end
+
       describe "index", tags: "search" do
         pending "searchs on keys"
         pending "returns settings for a set of parent ids"

--- a/spec/controllers/settings_spec.cr
+++ b/spec/controllers/settings_spec.cr
@@ -9,13 +9,12 @@ module PlaceOS::Api
 
       describe "support user" do
         context "access" do
-          _, support_header = authentication(sys_admin: false, support: true)
-          sys = Model::Generator.control_system.save!
-          setting = Model::Generator.settings(encryption_level: Encryption::Level::None, control_system: sys)
-          setting.settings_string = "tree: 1"
-          setting.save!
-
           it "index" do
+            _, support_header = authentication(sys_admin: false, support: true)
+            sys = Model::Generator.control_system.save!
+            setting = Model::Generator.settings(encryption_level: Encryption::Level::None, control_system: sys)
+            setting.settings_string = "tree: 1"
+            setting.save!
             result = curl(
               method: "GET",
               path: File.join(base, "?parent_id=#{sys.id}"),
@@ -26,6 +25,11 @@ module PlaceOS::Api
           end
 
           it "show" do
+            _, support_header = authentication(sys_admin: false, support: true)
+            sys = Model::Generator.control_system.save!
+            setting = Model::Generator.settings(encryption_level: Encryption::Level::None, control_system: sys)
+            setting.settings_string = "tree: 1"
+            setting.save!
             result = curl(
               method: "GET",
               path: File.join(base, setting.id.as(String)),


### PR DESCRIPTION
- Introduces option to specify `sys_admin` and `support` of a generated user in args to `authentication`
- Adds specs for support views on `../settings`

Resolves PlaceOS/backoffice/issues/154