### PR TITLE
Metadata endpoints on entites

### DIFF
--- a/spec/systems_spec.cr
+++ b/spec/systems_spec.cr
@@ -467,6 +467,28 @@ module PlaceOS::Api
           end
         end
       end
+
+      describe "/:id/metadata" do
+        it "shows system metadata" do
+          system = Model::Generator.control_system.save!
+          system_id = system.id.as(String)
+          meta = Model::Generator.metadata(name: "special", parent: system_id).save!
+
+          result = curl(
+            method: "GET",
+            path: base + "#{system_id}/metadata",
+            headers: authorization_header,
+          )
+
+          metadata = Hash(String, Model::Metadata::Interface).from_json(result.body)
+          metadata.size.should eq 1
+          metadata.first[1].parent_id.should eq system_id
+          metadata.first[1].name.should eq meta.name
+
+          system.destroy
+          meta.destroy
+        end
+      end
     end
   end
 end

--- a/spec/users_spec.cr
+++ b/spec/users_spec.cr
@@ -126,6 +126,28 @@ module PlaceOS::Api
           response_user.id.should eq authenticated_user.id
         end
       end
+
+      describe "/:id/metadata" do
+        it "shows user metadata" do
+          user = Model::Generator.user.save!
+          user_id = user.id.as(String)
+          meta = Model::Generator.metadata(name: "special", parent: user_id).save!
+
+          result = curl(
+            method: "GET",
+            path: base + "#{user_id}/metadata",
+            headers: authorization_header,
+          )
+
+          metadata = Hash(String, Model::Metadata::Interface).from_json(result.body)
+          metadata.size.should eq 1
+          metadata.first[1].parent_id.should eq user_id
+          metadata.first[1].name.should eq meta.name
+
+          user.destroy
+          meta.destroy
+        end
+      end
     end
   end
 end

--- a/spec/zones_spec.cr
+++ b/spec/zones_spec.cr
@@ -51,7 +51,6 @@ module PlaceOS::Api
           )
 
           metadata = Hash(String, Model::Metadata::Interface).from_json(result.body)
-          puts metadata
           metadata.size.should eq 1
           metadata.first[1].parent_id.should eq zone_id
           metadata.first[1].name.should eq meta.name

--- a/spec/zones_spec.cr
+++ b/spec/zones_spec.cr
@@ -37,6 +37,29 @@ module PlaceOS::Api
           updated.destroy
         end
       end
+
+      describe "/:id/metadata" do
+        it "shows zone metadata" do
+          zone = Model::Generator.zone.save!
+          zone_id = zone.id.as(String)
+          meta = Model::Generator.metadata(name: "special", parent: zone_id).save!
+
+          result = curl(
+            method: "GET",
+            path: base + "#{zone_id}/metadata",
+            headers: authorization_header,
+          )
+
+          metadata = Hash(String, Model::Metadata::Interface).from_json(result.body)
+          puts metadata
+          metadata.size.should eq 1
+          metadata.first[1].parent_id.should eq zone_id
+          metadata.first[1].name.should eq meta.name
+
+          zone.destroy
+          meta.destroy
+        end
+      end
     end
   end
 end

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -34,7 +34,8 @@ module PlaceOS::Api
     before_action :check_support, only: [:state, :state_lookup, :functions]
 
     before_action :current_control_system, only: [:show, :update, :destroy, :remove,
-                                                  :start, :stop, :execute, :types, :functions]
+                                                  :start, :stop, :execute,
+                                                  :types, :functions, :metadata]
 
     before_action :ensure_json, only: [:create, :update, :update_alt, :execute]
     before_action :body, only: [:create, :execute, :update, :update_alt]
@@ -200,6 +201,14 @@ module PlaceOS::Api
       set_collection_headers(documents.size, Model::Zone.table_name)
 
       render json: documents
+    end
+
+    # Return metadata for the system
+    #
+    get "/:sys_id/metadata", :metadata do
+      parent_id = current_control_system.id.not_nil!
+      name = params["name"]?.presence
+      render json: Model::Metadata.build_metadata(parent_id, name)
     end
 
     # Receive the collated settings for a system

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -2,6 +2,7 @@ require "oauth2"
 require "CrystalEmail"
 
 require "./application"
+require "./metadata"
 
 module PlaceOS::Api
   class Users < Application
@@ -9,7 +10,7 @@ module PlaceOS::Api
 
     base "/api/engine/v2/users/"
 
-    before_action :user, only: [:destroy, :update, :show]
+    before_action :user, only: [:destroy, :update, :show, :metadata]
 
     before_action :check_admin, only: [:index, :destroy, :create]
     before_action :check_authorization, only: [:update, :update_alt]
@@ -150,6 +151,12 @@ module PlaceOS::Api
     end
 
     ###############################################################################################
+
+    get "/:id/metadata", :metadata do
+      parent_id = user.id.not_nil!
+      name = params["name"]?.presence
+      render json: Model::Metadata.build_metadata(parent_id, name)
+    end
 
     # # Params
     # - `emails`: comma-seperated list of emails *required*

--- a/src/placeos-rest-api/controllers/zones.cr
+++ b/src/placeos-rest-api/controllers/zones.cr
@@ -9,7 +9,7 @@ module PlaceOS::Api
 
     before_action :check_admin, except: [:index, :show]
     before_action :check_support, except: [:index]
-    before_action :current_zone, only: [:show, :update, :update_alt, :destroy]
+    before_action :current_zone, only: [:show, :update, :update_alt, :destroy, :metadata]
 
     before_action :body, only: [:create, :update, :update_alt, :zone_execute]
 
@@ -72,6 +72,12 @@ module PlaceOS::Api
     def destroy
       current_zone.destroy
       head :ok
+    end
+
+    get "/:id/metadata", :metadata do
+      parent_id = current_zone.id.not_nil!
+      name = params["name"]?.presence
+      render json: Model::Metadata.build_metadata(parent_id, name)
     end
 
     private enum ExecStatus


### PR DESCRIPTION
Adds the following endpoints:
- `GET /users/:id/metadata`
- `GET /zones/:id/metadata`
- `GET /systems/:id/metadata`

ID resolution uses the local behaviour provided by the parent controller. This enabled metadata queries directly using new user lookup introduced via #157. `name` query param supported across all endpoints for parity with the base `/metadata` controller.

Closes #158.