### PR TITLE
chore: placeos-models ~>5.9

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -147,7 +147,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 5.8.0
+    version: 5.10.0
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -51,7 +51,7 @@ end
 CREATION_LOCK = Mutex.new(protection: :reentrant)
 
 # Yield an authenticated user, and a header with X-API-Key set
-def x_api_authentication(sys_admin : Bool = true, support : Bool = true, scope = ["public"] of String)
+def x_api_authentication(sys_admin : Bool = true, support : Bool = true, scope = [PlaceOS::Model::UserJWT::PUBLIC])
   CREATION_LOCK.synchronize do
     user, _header = authentication(sys_admin, support, scope)
     unless api_key = user.api_tokens.first?
@@ -71,10 +71,10 @@ end
 
 # Yield an authenticated user, and a header with Authorization bearer set
 # This method is synchronised due to the redundant top-level calls.
-def authentication(sys_admin : Bool = true, support : Bool = true, scope = ["public"] of String)
+def authentication(sys_admin : Bool = true, support : Bool = true, scope = [PlaceOS::Model::UserJWT::PUBLIC])
   CREATION_LOCK.synchronize do
     test_user_email = "test-admin-#{sys_admin ? "1" : "0"}-supp-#{support ? "1" : "0"}-rest-api@place.tech"
-    existing = PlaceOS::Model::User.find_all([test_user_email], index: :email).first?
+    existing = PlaceOS::Model::User.where(email: test_user_email).first?
 
     authenticated_user = if existing
                            existing

--- a/spec/root_spec.cr
+++ b/spec/root_spec.cr
@@ -101,7 +101,7 @@ module PlaceOS::Api
         end
 
         context "guests" do
-          _, guest_header = authentication(sys_admin: false, support: false, scope: ["guest"])
+          _, guest_header = authentication(sys_admin: false, support: false, scope: [PlaceOS::Model::UserJWT::GUEST])
 
           it "prevented access to non-guest channels " do
             result = curl("POST", File.join(base, "signal?channel=dummy"), body: "hello", headers: guest_header)

--- a/src/placeos-rest-api/controllers/metadata.cr
+++ b/src/placeos-rest-api/controllers/metadata.cr
@@ -26,7 +26,7 @@ module PlaceOS::Api
       name = params["name"]?.presence
 
       # Guest JWTs include the control system id that they have access to
-      if user_token.scope.includes?("guest")
+      if user_token.guest_scope?
         head :forbidden unless name && guest_ids.includes?(parent_id)
       end
 
@@ -51,7 +51,7 @@ module PlaceOS::Api
       include_parent = params.has_key?("include_parent") ? params["include_parent"].downcase == "true" : true
 
       # Guest JWTs include the control system id that they have access to
-      if user_token.scope.includes?("guest")
+      if user_token.guest_scope?
         head :forbidden unless name && guest_ids.includes?(parent_id)
       end
 

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -148,7 +148,7 @@ module PlaceOS::Api
       args = SignalParams.new(params).validate!
       channel = args.channel
 
-      if user_token.scope.includes?("guest")
+      if user_token.guest_scope?
         head :forbidden unless channel.includes?("/guest/")
       end
 

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -135,7 +135,7 @@ module PlaceOS::Api
     # Renders a control system
     def show
       # Guest JWTs include the control system id that they have access to
-      if user_token.scope.includes?("guest")
+      if user_token.guest_scope?
         head :forbidden unless user_token.user.roles.includes?(current_control_system.id)
         render json: current_control_system
       end
@@ -187,7 +187,7 @@ module PlaceOS::Api
     #
     get "/:sys_id/zones", :sys_zones do
       # Guest JWTs include the control system id that they have access to
-      if user_token.scope.includes?("guest")
+      if user_token.guest_scope?
         head :forbidden unless user_token.user.roles.includes?(params["sys_id"])
       end
 

--- a/src/placeos-rest-api/utilities/current-user.cr
+++ b/src/placeos-rest-api/utilities/current-user.cr
@@ -60,7 +60,7 @@ module PlaceOS::Api
 
     def check_oauth_scope
       utoken = user_token
-      unless utoken.scope.includes?("public")
+      unless utoken.public_scope?
         Log.warn { {message: "unknown scope #{utoken.scope}", action: "authorize!", host: request.hostname, id: utoken.id} }
         raise Error::Unauthorized.new "public scope required for access"
       end


### PR DESCRIPTION
Provides a minimal change set need to bump `placeos-models` for compatibility with updated email digests.

Supercedes #179 while #169 is in progress.
