### PR TITLE
fix(session): args is optional

### DIFF
--- a/src/placeos-rest-api/session.cr
+++ b/src/placeos-rest-api/session.cr
@@ -639,7 +639,7 @@ module PlaceOS
       in .debug?  then debug(**arguments)
       in .ignore? then ignore(**arguments)
       in .exec?
-        args = request.args.as(Array(JSON::Any))
+        args = request.args || [] of JSON::Any
         exec(**arguments.merge({args: args}))
       end
     end


### PR DESCRIPTION
casting here raises a runtime error, we'll default to an empty array if not provided