### PR TITLE
refactor(api): unify boolean param handling

### DIFF
--- a/src/placeos-rest-api/controllers/application.cr
+++ b/src/placeos-rest-api/controllers/application.cr
@@ -26,6 +26,16 @@ module PlaceOS::Api
     # Default sort for elasticsearch
     NAME_SORT_ASC = {"name.keyword" => {order: :asc}}
 
+    def boolean_param(key : String, default : Bool = false, allow_empty : Bool = false) : Bool
+      return true if allow_empty && params.has_key?(key) && params[key].nil?
+
+      case params[key]?.presence.try(&.downcase)
+      when .in?("1", "true")  then true
+      when .in?("0", "false") then false
+      else                         default
+      end
+    end
+
     def paginate_results(elastic, query, route = base_route)
       data = elastic.search(query)
       range_start = query.offset

--- a/src/placeos-rest-api/controllers/drivers.cr
+++ b/src/placeos-rest-api/controllers/drivers.cr
@@ -46,7 +46,7 @@ module PlaceOS::Api
     end
 
     def show
-      include_compilation_status = !params.has_key?("compilation_status") || params["compilation_status"] != "false"
+      include_compilation_status = boolean_param("compilation_status", default: true)
 
       result = !include_compilation_status ? current_driver : with_fields(current_driver, {
         :compilation_status => Api::Drivers.compilation_status(current_driver, request_id),

--- a/src/placeos-rest-api/controllers/metadata.cr
+++ b/src/placeos-rest-api/controllers/metadata.cr
@@ -56,7 +56,7 @@ module PlaceOS::Api
     get "/:id/children", :children_metadata do
       parent_id = params["id"]
       name = params["name"]?.presence
-      include_parent = params.has_key?("include_parent") ? params["include_parent"].downcase == "true" : true
+      include_parent = boolean_param("include_parent", default: true)
 
       # Guest JWTs include the control system id that they have access to
       if user_token.guest_scope?

--- a/src/placeos-rest-api/controllers/modules.cr
+++ b/src/placeos-rest-api/controllers/modules.cr
@@ -142,7 +142,7 @@ module PlaceOS::Api
     end
 
     def show
-      complete = params["complete"]? == "true"
+      complete = boolean_param("complete")
 
       response = !complete ? current_module : with_fields(current_module, {
         :driver => restrict_attributes(current_module.driver, only: DRIVER_ATTRIBUTES),

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -170,7 +170,7 @@ module PlaceOS::Api
     end
 
     getter? backfill : Bool do
-      params["backfill"]?.presence.in?("1", "true")
+      boolean_param("backfill")
     end
 
     post "/reindex", :reindex do

--- a/src/placeos-rest-api/controllers/system-triggers.cr
+++ b/src/placeos-rest-api/controllers/system-triggers.cr
@@ -78,7 +78,7 @@ module PlaceOS::Api
 
     def show
       # Default to render extra association fields
-      complete = params.has_key?("complete") ? params["complete"]? == "true" : true
+      complete = boolean_param("complete", default: true)
       render json: render_system_trigger(current_sys_trig, complete: complete)
     end
 

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -155,7 +155,7 @@ module PlaceOS::Api
         render json: current_control_system
       end
 
-      complete = params["complete"]? == "true"
+      complete = boolean_param("complete")
       render json: !complete ? current_control_system : with_fields(current_control_system, {
         :module_data => current_control_system.module_data,
         :zone_data   => current_control_system.zone_data,
@@ -410,8 +410,7 @@ module PlaceOS::Api
 
     ws("/control", :control) do |ws|
       Log.trace { "WebSocket API request" }
-      fixed_device = params["fixed_device"]?.try(&.downcase) == "true"
-      Log.context.set(fixed_device: fixed_device)
+      Log.context.set(fixed_device: boolean_param("fixed_device"))
       Systems.session_manager.create_session(
         ws: ws,
         request_id: request_id,

--- a/src/placeos-rest-api/controllers/triggers.cr
+++ b/src/placeos-rest-api/controllers/triggers.cr
@@ -33,7 +33,7 @@ module PlaceOS::Api
     end
 
     def show
-      include_instances = params["instances"]? == "true"
+      include_instances = boolean_param("instances")
       render json: !include_instances ? current_trigger : with_fields(current_trigger, {
         :trigger_instances => current_trigger.trigger_instances.to_a,
       })

--- a/src/placeos-rest-api/controllers/webhook.cr
+++ b/src/placeos-rest-api/controllers/webhook.cr
@@ -37,7 +37,7 @@ module PlaceOS::Api
       )
 
       # Execute the requested method
-      if params["exec"]? == "true"
+      if boolean_param("exec")
         exec_params = ExecParams.new(params).validate!
 
         if current_trigger_instance.exec_enabled

--- a/src/placeos-rest-api/controllers/zones.cr
+++ b/src/placeos-rest-api/controllers/zones.cr
@@ -57,9 +57,8 @@ module PlaceOS::Api
       render json: paginate_results(elastic, query)
     end
 
-    # BREAKING CHANGE: param key `data` used to attempt to retrieve a setting from the zone
     def show
-      if params.has_key? "complete"
+      if boolean_param("complete", allow_empty: true)
         # Include trigger data in response
         render json: with_fields(current_zone, {
           :trigger_data => current_zone.trigger_data,


### PR DESCRIPTION
Unifies boolean param handling across the API.
Old behaviours are preserved (including empty params)