### PR TITLE
refactor: param getters

### DIFF
--- a/spec/controllers/edges/connection_manager_spec.cr
+++ b/spec/controllers/edges/connection_manager_spec.cr
@@ -1,0 +1,6 @@
+require "../../helper"
+
+module PlaceOS::Api
+  pending Edges::ConnectionManager do
+  end
+end

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -19,6 +19,7 @@ end
 
 Spec.before_each do
   PlaceOS::Api::HttpMocks.reset
+  PlaceOS::Api::HttpMocks.etcd_range
 end
 
 Spec.after_suite { clear_tables }

--- a/src/placeos-rest-api/controllers/api_keys.cr
+++ b/src/placeos-rest-api/controllers/api_keys.cr
@@ -17,16 +17,26 @@ module PlaceOS::Api
 
     before_action :body, only: [:create, :update, :update_alt]
 
+    # Params
+    ###############################################################################################
+
+    getter authority_id : String? do
+      params["authority_id"]?.presence
+    end
+
     ###############################################################################################
 
     getter current_api_key : Model::ApiKey { find_api_key }
+
+    ###############################################################################################
 
     def index
       elastic = Model::ApiKey.elastic
       query = elastic.query(params)
 
-      authority_id = params["authority_id"]?
-      query.filter({"authority_id" => [authority_id]}) if authority_id
+      if authority = authority_id
+        query.filter({"authority_id" => [authority]})
+      end
 
       query.sort(NAME_SORT_ASC)
 

--- a/src/placeos-rest-api/controllers/application.cr
+++ b/src/placeos-rest-api/controllers/application.cr
@@ -26,6 +26,13 @@ module PlaceOS::Api
     # Default sort for elasticsearch
     NAME_SORT_ASC = {"name.keyword" => {order: :asc}}
 
+    macro required_param(key)
+      if (%value = {{ key }}).nil?
+        return render_error(HTTP::Status::BAD_REQUEST, "Missing '{{ key }}' param")
+      end
+      %value
+    end
+
     def boolean_param(key : String, default : Bool = false, allow_empty : Bool = false) : Bool
       return true if allow_empty && params.has_key?(key) && params[key].nil?
 

--- a/src/placeos-rest-api/controllers/authentications.cr
+++ b/src/placeos-rest-api/controllers/authentications.cr
@@ -20,6 +20,13 @@ module PlaceOS::Api
       before_action :current_auth, only: [:show, :update, :update_alt, :destroy]
       before_action :body, only: [:create, :update, :update_alt]
 
+      # Params
+      ###############################################################################################
+
+      getter authority_id : String? do
+        params["authority_id"].presence || params["authority"]?.presence
+      end
+
       ###############################################################################################
 
       getter current_auth : Model::{{auth_type.id}}Authentication { find_auth }
@@ -28,7 +35,7 @@ module PlaceOS::Api
         elastic = Model::{{auth_type.id}}Authentication.elastic
         query = elastic.query(params)
 
-        if authority = params["authority"]?
+        if authority = authority_id
           query.filter({
             "authority_id" => [authority],
           })

--- a/src/placeos-rest-api/controllers/cluster.cr
+++ b/src/placeos-rest-api/controllers/cluster.cr
@@ -1,7 +1,7 @@
-require "promise"
-require "./application"
-
 require "placeos-core-client"
+require "promise"
+
+require "./application"
 
 module PlaceOS::Api
   class Cluster < Application
@@ -14,17 +14,23 @@ module PlaceOS::Api
     before_action :can_read, only: [:index, :show]
     before_action :can_write, only: [:destroy]
 
+    # Params
     ###############################################################################################
 
-    class ClusterParams < Params
-      attribute include_status : Bool = false
+    getter? include_status : Bool do
+      boolean_param("include_status")
     end
+
+    getter driver : String do
+      params["driver"]
+    end
+
+    ###############################################################################################
 
     def index
       details = self.class.core_discovery.node_hash
-      arguments = ClusterParams.new(params)
 
-      if arguments.include_status
+      if include_status?
         promises = details.map do |core_id, uri|
           Promise.defer {
             Cluster.node_status(core_id, uri, request_id)
@@ -92,10 +98,9 @@ module PlaceOS::Api
 
     def show
       core_id = params["id"]
-      args = ClusterParams.new(params)
       uri = self.class.core_discovery.node_hash[core_id]?
 
-      Log.context.set({core_id: core_id, uri: uri.try &.to_s, include_status: args.include_status})
+      Log.context.set(core_id: core_id, uri: uri.try &.to_s, include_status: include_status?)
 
       if uri.nil?
         Log.debug { "core not registered" }
@@ -110,7 +115,7 @@ module PlaceOS::Api
 
         Log.debug { {loaded: loaded.to_json} }
 
-        if args.include_status
+        if include_status?
           promises = driver_keys.map do |key|
             Promise.defer(timeout: 1.second) do
               driver_status = begin
@@ -184,7 +189,6 @@ module PlaceOS::Api
 
     def destroy
       core_id = params["id"]
-      driver = params["driver"]
 
       uri = self.class.core_discovery.node_hash[core_id]
       if Core::Client.client(uri, request_id, &.terminate(driver))

--- a/src/placeos-rest-api/controllers/cluster.cr
+++ b/src/placeos-rest-api/controllers/cluster.cr
@@ -25,6 +25,10 @@ module PlaceOS::Api
       params["driver"]
     end
 
+    getter core_id : String do
+      params["id"]
+    end
+
     ###############################################################################################
 
     def index
@@ -97,7 +101,6 @@ module PlaceOS::Api
     end
 
     def show
-      core_id = params["id"]
       uri = self.class.core_discovery.node_hash[core_id]?
 
       Log.context.set(core_id: core_id, uri: uri.try &.to_s, include_status: include_status?)
@@ -188,8 +191,6 @@ module PlaceOS::Api
     end
 
     def destroy
-      core_id = params["id"]
-
       uri = self.class.core_discovery.node_hash[core_id]
       if Core::Client.client(uri, request_id, &.terminate(driver))
         head :ok

--- a/src/placeos-rest-api/controllers/drivers.cr
+++ b/src/placeos-rest-api/controllers/drivers.cr
@@ -25,6 +25,7 @@ module PlaceOS::Api
 
     def index
       # Pick off role from HTTP params, render error if present and invalid
+      # TODO: This is an example of a need to improve validation model of params.
       role = params["role"]?.try &.to_i?.try do |r|
         parsed = Model::Driver::Role.from_value?(r)
         return render_error(HTTP::Status::UNPROCESSABLE_ENTITY, "Invalid `role`") if parsed.nil?

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -40,17 +40,15 @@ module PlaceOS::Api
 
     # Validate the present of the id and check the secret before routing to core
     ws("/control", :edge) do |socket|
-      if (authentication_token = token).nil?
-        return render_error(HTTP::Status::BAD_REQUEST, "Missing 'token' param")
+      authentication_token = required_param(token)
 
-        edge_id = Model::Edge.validate_token?(authentication_token)
+      edge_id = Model::Edge.validate_token?(authentication_token)
 
-        if edge_id.nil?
-          head status: :unauthorized
-        else
-          Log.info { {edge_id: edge_id, message: "new edge connection"} }
-          Edges.connection_manager.add_edge(edge_id, socket)
-        end
+      if edge_id.nil?
+        head status: :unauthorized
+      else
+        Log.info { {edge_id: edge_id, message: "new edge connection"} }
+        Edges.connection_manager.add_edge(edge_id, socket)
       end
     end
 

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -1,5 +1,3 @@
-require "hound-dog"
-require "placeos-core-client"
 require "promise"
 
 require "./application"
@@ -27,6 +25,13 @@ module PlaceOS::Api
     skip_action :authorize!, only: [:edge]
     skip_action :set_user_id, only: [:edge]
 
+    # Params
+    ###############################################################################################
+
+    getter token : String? do
+      params["token"]?.presence
+    end
+
     ###############################################################################################
 
     getter current_edge : Model::Edge { find_edge }
@@ -35,17 +40,18 @@ module PlaceOS::Api
 
     # Validate the present of the id and check the secret before routing to core
     ws("/control", :edge) do |socket|
-      token = params["token"]?
+      if (authentication_token = token).nil?
+        return render_error(HTTP::Status::BAD_REQUEST, "Missing 'token' param")
 
-      return render_error(HTTP::Status::BAD_REQUEST, "Missing 'token' param") if token.nil? || token.presence.nil?
+        edge_id = Model::Edge.validate_token?(authentication_token)
 
-      edge_id = Model::Edge.validate_token?(token)
-
-      head status: :unauthorized if edge_id.nil?
-
-      Log.info { {edge_id: edge_id, message: "new edge connection"} }
-
-      Edges.connection_manager.add_edge(edge_id, socket)
+        if edge_id.nil?
+          head status: :unauthorized
+        else
+          Log.info { {edge_id: edge_id, message: "new edge connection"} }
+          Edges.connection_manager.add_edge(edge_id, socket)
+        end
+      end
     end
 
     get("/:id/token", :token) do
@@ -90,165 +96,7 @@ module PlaceOS::Api
       # Find will raise a 404 (not found) if there is an error
       Model::Edge.find!(id, runopts: {"read_mode" => "majority"})
     end
-
-    # Edge Connection Management
-    ###########################################################################
-
-    # Handles the websocket proxy between Edge and Core
-    #
-    # TODO: Use a single socket per core
-    class ConnectionManager
-      Log = ::Log.for(self)
-
-      private getter edge_mapping = {} of String => HoundDog::Service::Node
-      private getter edge_sockets = {} of String => HTTP::WebSocket
-      private getter core_sockets = {} of String => HTTP::WebSocket
-
-      private getter edge_lock = Mutex.new(protection: :reentrant)
-
-      getter core_discovery : Api::Discovery::Core
-
-      def initialize(@core_discovery : Api::Discovery::Core)
-        @core_discovery.callbacks << ->rebalance(Array(HoundDog::Service::Node))
-      end
-
-      def add_edge(edge_id : String, socket : HTTP::WebSocket)
-        Log.debug { {edge_id: edge_id, message: "adding edge socket"} }
-        edge_lock.synchronize do
-          edge_sockets[edge_id] = socket
-          add_core(edge_id, current_node: core_discovery.find(edge_id))
-        end
-
-        spawn(same_thread: true) do
-          loop do
-            socket.ping rescue break
-            sleep 30
-          end
-        end
-
-        socket.on_close { remove(edge_id) }
-      rescue e
-        Log.error(exception: e) { {edge_id: edge_id, message: "while adding edge socket"} }
-        remove(edge_id)
-        socket.close
-      end
-
-      def remove(edge_id : String)
-        edge_lock.synchronize do
-          mapping = edge_mapping.delete(edge_id)
-          uri = mapping.try &.[:uri].to_s
-
-          if socket = core_sockets.delete(edge_id)
-            socket.close rescue nil
-            Log.info { {message: "closed socket to core", edge_id: edge_id, core_uri: uri} }
-          end
-
-          if socket = edge_sockets.delete(edge_id)
-            socket.close rescue nil
-            Log.info { {message: "closed socket to edge", edge_id: edge_id, core_uri: uri} }
-          end
-        end
-      end
-
-      def add_core(
-        edge_id : String,
-        rendezvous : RendezvousHash = core_discovery.rendezvous,
-        current_node : HoundDog::Service::Node? = nil,
-        reconnect : Bool = false
-      )
-        node = rendezvous[edge_id]?.try &->HoundDog::Discovery.from_hash_value(String)
-
-        raise "no core found" if node.nil?
-
-        # No need to change connection
-        if !reconnect && core_sockets.has_key?(edge_id) && current_node && node[:name] == current_node[:name]
-          return
-        end
-
-        Log.debug { {edge_id: edge_id, message: "adding core socket"} }
-
-        uri = node[:uri]
-        uri.query = "edge_id=#{edge_id}"
-        uri.path = "/api/core/v1/edge/control"
-
-        socket = edge_lock.synchronize do
-          edge_socket = edge_sockets[edge_id]
-          core_socket = HTTP::WebSocket.new(uri)
-          core_socket.on_close do
-            begin
-              Retriable.retry(
-                max_interval: 5.seconds,
-                max_elapsed_time: 1.minute,
-                on_retry: ->(error : Exception, _i : Int32, _e : Time::Span, _p : Time::Span) {
-                  Log.warn { {error: error.to_s, edge_id: edge_id, message: "reconnecting edge to core"} }
-                }) do
-                add_core(edge_id, reconnect: true) if edge_mapping.has_key?(edge_id)
-              end
-            rescue error
-              Log.error { {
-                message:  "failed to reconnect to core",
-                edge_id:  edge_id,
-                core_uri: edge_mapping[edge_id]?.try &.[:uri].to_s,
-              } }
-              remove(edge_id)
-            end
-          end
-
-          # Link core to edge
-          core_socket.on_message { |message|
-            Log.debug { {message: "from core", packet: message} }
-            edge_socket.send(message)
-          }
-          core_socket.on_binary { |bytes| edge_socket.stream &.write(bytes) }
-
-          # Link edge to core
-          edge_socket.on_message { |message|
-            Log.debug { {message: "from edge", packet: message} }
-            core_socket.send(message)
-          }
-
-          edge_socket.on_binary { |bytes| core_socket.stream &.write(bytes) }
-
-          core_sockets[edge_id]?.try(&.close) rescue nil
-          core_sockets[edge_id] = core_socket
-          core_socket
-        end
-
-        Log.debug { {edge_id: edge_id, message: "successfully added edge to core connection"} }
-
-        spawn(same_thread: true) do
-          begin
-            socket.run
-          rescue e
-            Log.error(exception: e) { "core websocket failure" }
-          end
-        end
-
-        Fiber.yield
-        socket
-      end
-
-      def rebalance(nodes : Array(HoundDog::Service::Node))
-        Log.info { "rebalancing edge connections" }
-
-        rendezvous = RendezvousHash.new(nodes.map(&->HoundDog::Discovery.to_hash_value(HoundDog::Service::Node)))
-
-        edge_lock.synchronize do
-          # Asynchronously refresh core connections
-          Promise.map(edge_mapping) do |(edge_id, core_node)|
-            begin
-              Retriable.retry(max_interval: 1.seconds, max_elapsed_time: 20.seconds, on_retry: ->(e : Exception, _i : Int32, _e : Time::Span, _p : Time::Span) {
-                Log.warn { {error: e.to_s, edge_id: edge_id, message: "retrying connection to core"} }
-              }) do
-                add_core(edge_id, current_node: core_node, rendezvous: rendezvous)
-              end
-            rescue error
-              Log.error(exception: error) { {message: "failed to connect to core", edge_id: edge_id} }
-              remove(edge_id)
-            end
-          end.get
-        end
-      end
-    end
   end
 end
+
+require "./edges/connection_manager"

--- a/src/placeos-rest-api/controllers/edges/connection_manager.cr
+++ b/src/placeos-rest-api/controllers/edges/connection_manager.cr
@@ -1,0 +1,164 @@
+require "hound-dog"
+require "placeos-core-client"
+
+module PlaceOS::Api
+  ###########################################################################
+  # Edge Connection Management
+  #
+  # Handles the websocket proxy between Edge and Core
+  #
+  # TODO: Use a single socket per core
+  class Edges::ConnectionManager
+    Log = ::Log.for(self)
+
+    private getter edge_mapping = {} of String => HoundDog::Service::Node
+    private getter edge_sockets = {} of String => HTTP::WebSocket
+    private getter core_sockets = {} of String => HTTP::WebSocket
+
+    private getter edge_lock = Mutex.new(protection: :reentrant)
+
+    getter core_discovery : Api::Discovery::Core
+
+    def initialize(@core_discovery : Api::Discovery::Core)
+      @core_discovery.callbacks << ->rebalance(Array(HoundDog::Service::Node))
+    end
+
+    def add_edge(edge_id : String, socket : HTTP::WebSocket)
+      Log.debug { {edge_id: edge_id, message: "adding edge socket"} }
+      edge_lock.synchronize do
+        edge_sockets[edge_id] = socket
+        add_core(edge_id, current_node: core_discovery.find(edge_id))
+      end
+
+      spawn(same_thread: true) do
+        loop do
+          socket.ping rescue break
+          sleep 30
+        end
+      end
+
+      socket.on_close { remove(edge_id) }
+    rescue e
+      Log.error(exception: e) { {edge_id: edge_id, message: "while adding edge socket"} }
+      remove(edge_id)
+      socket.close
+    end
+
+    def remove(edge_id : String)
+      edge_lock.synchronize do
+        mapping = edge_mapping.delete(edge_id)
+        uri = mapping.try &.[:uri].to_s
+
+        if socket = core_sockets.delete(edge_id)
+          socket.close rescue nil
+          Log.info { {message: "closed socket to core", edge_id: edge_id, core_uri: uri} }
+        end
+
+        if socket = edge_sockets.delete(edge_id)
+          socket.close rescue nil
+          Log.info { {message: "closed socket to edge", edge_id: edge_id, core_uri: uri} }
+        end
+      end
+    end
+
+    def add_core(
+      edge_id : String,
+      rendezvous : RendezvousHash = core_discovery.rendezvous,
+      current_node : HoundDog::Service::Node? = nil,
+      reconnect : Bool = false
+    )
+      node = rendezvous[edge_id]?.try &->HoundDog::Discovery.from_hash_value(String)
+
+      raise "no core found" if node.nil?
+
+      # No need to change connection
+      if !reconnect && core_sockets.has_key?(edge_id) && current_node && node[:name] == current_node[:name]
+        return
+      end
+
+      Log.debug { {edge_id: edge_id, message: "adding core socket"} }
+
+      uri = node[:uri]
+      uri.query = "edge_id=#{edge_id}"
+      uri.path = "/api/core/v1/edge/control"
+
+      socket = edge_lock.synchronize do
+        edge_socket = edge_sockets[edge_id]
+        core_socket = HTTP::WebSocket.new(uri)
+        core_socket.on_close do
+          begin
+            Retriable.retry(
+              max_interval: 5.seconds,
+              max_elapsed_time: 1.minute,
+              on_retry: ->(error : Exception, _i : Int32, _e : Time::Span, _p : Time::Span) {
+                Log.warn { {error: error.to_s, edge_id: edge_id, message: "reconnecting edge to core"} }
+              }) do
+              add_core(edge_id, reconnect: true) if edge_mapping.has_key?(edge_id)
+            end
+          rescue error
+            Log.error { {
+              message:  "failed to reconnect to core",
+              edge_id:  edge_id,
+              core_uri: edge_mapping[edge_id]?.try &.[:uri].to_s,
+            } }
+            remove(edge_id)
+          end
+        end
+
+        # Link core to edge
+        core_socket.on_message { |message|
+          Log.debug { {message: "from core", packet: message} }
+          edge_socket.send(message)
+        }
+        core_socket.on_binary { |bytes| edge_socket.stream &.write(bytes) }
+
+        # Link edge to core
+        edge_socket.on_message { |message|
+          Log.debug { {message: "from edge", packet: message} }
+          core_socket.send(message)
+        }
+
+        edge_socket.on_binary { |bytes| core_socket.stream &.write(bytes) }
+
+        core_sockets[edge_id]?.try(&.close) rescue nil
+        core_sockets[edge_id] = core_socket
+        core_socket
+      end
+
+      Log.debug { {edge_id: edge_id, message: "successfully added edge to core connection"} }
+
+      spawn(same_thread: true) do
+        begin
+          socket.run
+        rescue e
+          Log.error(exception: e) { "core websocket failure" }
+        end
+      end
+
+      Fiber.yield
+      socket
+    end
+
+    def rebalance(nodes : Array(HoundDog::Service::Node))
+      Log.info { "rebalancing edge connections" }
+
+      rendezvous = RendezvousHash.new(nodes.map(&->HoundDog::Discovery.to_hash_value(HoundDog::Service::Node)))
+
+      edge_lock.synchronize do
+        # Asynchronously refresh core connections
+        Promise.map(edge_mapping) do |(edge_id, core_node)|
+          begin
+            Retriable.retry(max_interval: 1.seconds, max_elapsed_time: 20.seconds, on_retry: ->(e : Exception, _i : Int32, _e : Time::Span, _p : Time::Span) {
+              Log.warn { {error: e.to_s, edge_id: edge_id, message: "retrying connection to core"} }
+            }) do
+              add_core(edge_id, current_node: core_node, rendezvous: rendezvous)
+            end
+          rescue error
+            Log.error(exception: error) { {message: "failed to connect to core", edge_id: edge_id} }
+            remove(edge_id)
+          end
+        end.get
+      end
+    end
+  end
+end

--- a/src/placeos-rest-api/controllers/metadata.cr
+++ b/src/placeos-rest-api/controllers/metadata.cr
@@ -22,17 +22,30 @@ module PlaceOS::Api
 
     before_action :body, only: [:update, :update_alt]
 
+    # Params
+    ###############################################################################################
+
+    getter parent_id : String do
+      params["id"]
+    end
+
+    getter name : String? do
+      params["name"]?.presence
+    end
+
+    getter? include_parent : Bool do
+      boolean_param("include_parent", default: true)
+    end
+
     ###############################################################################################
 
     getter current_zone : Model::Zone { find_zone }
 
+    ###############################################################################################
     # Fetch metadata for a model
     #
     # Filter for a specific metadata by name via `name` param
     def show
-      parent_id = params["id"]
-      name = params["name"]?.presence
-
       # Guest JWTs include the control system id that they have access to
       if user_token.guest_scope?
         head :forbidden unless name && guest_ids.includes?(parent_id)
@@ -54,10 +67,6 @@ module PlaceOS::Api
     # Filter for a specific metadata by name via `name` param.
     # Includes the parent metadata by default via `include_parent` param.
     get "/:id/children", :children_metadata do
-      parent_id = params["id"]
-      name = params["name"]?.presence
-      include_parent = boolean_param("include_parent", default: true)
-
       # Guest JWTs include the control system id that they have access to
       if user_token.guest_scope?
         head :forbidden unless name && guest_ids.includes?(parent_id)
@@ -66,7 +75,7 @@ module PlaceOS::Api
       render_json do |json|
         json.array do
           current_zone.children.all.each do |zone|
-            Children.new(zone, name).to_json(json) if include_parent || zone.id != parent_id
+            Children.new(zone, name).to_json(json) if include_parent? || zone.id != parent_id
           end
         end
       end
@@ -74,7 +83,6 @@ module PlaceOS::Api
 
     # ameba:disable Metrics/CyclomaticComplexity
     def update
-      parent_id = params["id"]
       metadata = Model::Metadata::Interface.from_json(self.body)
 
       # We need a name to lookup the metadata
@@ -120,12 +128,11 @@ module PlaceOS::Api
     put "/:id", :update_alt { update }
 
     def destroy
-      parent_id = params["id"]
-      name = params["name"]?.presence
+      if (metadata_name = name).nil?
+        head :bad_request
+      end
 
-      head :bad_request unless name
-
-      Model::Metadata.for(parent_id, name).each &.destroy
+      Model::Metadata.for(parent_id, metadata_name).each &.destroy
 
       head :ok
     end
@@ -134,10 +141,9 @@ module PlaceOS::Api
     ###########################################################################
 
     def find_zone
-      id = params["id"]
-      Log.context.set(zone_id: id)
+      Log.context.set(zone_id: parent_id)
       # Find will raise a 404 (not found) if there is an error
-      Model::Zone.find!(id)
+      Model::Zone.find!(parent_id)
     end
 
     # Fetch zones for system the current user has a role for
@@ -148,7 +154,8 @@ module PlaceOS::Api
 
     # Does the user making the request have permissions to modify the data
     def check_delete_permissions
-      raise Error::Forbidden.new unless is_support? || params["id"] == user_token.id
+      # NOTE: Will the user token ever be assigned a zone id?
+      raise Error::Forbidden.new unless is_support? || parent_id == user_token.id
     end
   end
 end

--- a/src/placeos-rest-api/controllers/oauth_applications.cr
+++ b/src/placeos-rest-api/controllers/oauth_applications.cr
@@ -17,6 +17,13 @@ module PlaceOS::Api
     before_action :current_app, only: [:show, :update, :update_alt, :destroy]
     before_action :body, only: [:create, :update, :update_alt]
 
+    # Params
+    ###############################################################################################
+
+    getter authority_id : String? do
+      params["authority_id"]?.presence || params["authority"]?.presence
+    end
+
     ###############################################################################################
 
     getter current_app : Model::DoorkeeperApplication { find_app }
@@ -26,10 +33,10 @@ module PlaceOS::Api
       query = elastic.query(params)
       query.sort(NAME_SORT_ASC)
 
-      # filter by authority
-      if params.has_key? "authority"
+      # Filter by authority_id
+      if authority = authority_id
         query.must({
-          "owner_id" => [params["authority"]],
+          "owner_id" => [authority],
         })
       end
 

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -25,6 +25,21 @@ module PlaceOS::Api
     before_action :ensure_json, only: [:update, :update_alt]
     before_action :body, only: [:create, :update, :update_alt]
 
+    # Params
+    ###############################################################################################
+
+    getter name : String? do
+      params["name"]?.presence
+    end
+
+    getter emails : Array(String)? do
+      params["emails"]?.presence.try &.split(',')
+    end
+
+    getter authority_id : String? do
+      params["authority_id"]?.presence || params["authority"]?.presence
+    end
+
     ###############################################################################################
 
     getter user : Model::User { find_user }
@@ -107,8 +122,9 @@ module PlaceOS::Api
 
       query.must_not({"deleted" => [true]})
 
-      authority_id = params["authority_id"]?
-      query.filter({"authority_id" => [authority_id]}) if authority_id
+      if authority = authority_id
+        query.filter({"authority_id" => [authority]})
+      end
 
       render_json do |json|
         json.array do
@@ -163,7 +179,6 @@ module PlaceOS::Api
 
     get "/:id/metadata", :metadata do
       parent_id = user.id.not_nil!
-      name = params["name"]?.presence
       render json: Model::Metadata.build_metadata(parent_id, name)
     end
 
@@ -172,18 +187,16 @@ module PlaceOS::Api
     # # Returns
     # - `[{id: "<user-id>", groups: ["<group>"]}]`
     get("/groups", :groups) do
-      emails_param = params["emails"]?.presence
-      return render_error(HTTP::Status::BAD_REQUEST, "Missing `emails` param") if emails_param.nil?
+      emails_param = required_param(emails)
 
-      emails = emails_param.split(',')
-      errors = self.class.validate_emails(emails)
-
-      return render_error(HTTP::Status::UNPROCESSABLE_ENTITY, errors.join(", ")) unless errors.empty?
+      unless (errors = self.class.validate_emails(emails_param)).empty?
+        return render_error(HTTP::Status::UNPROCESSABLE_ENTITY, errors.join(", "))
+      end
 
       render_json do |json|
         json.array do
           Model::User
-            .find_by_emails(authority_id: current_user.authority_id.as(String), emails: emails)
+            .find_by_emails(authority_id: current_user.authority_id.as(String), emails: emails_param)
             .each &.to_group_json(json)
         end
       end


### PR DESCRIPTION
There remain a handful of raw accessed to `params`, however these
require more complex validation that is provided via the accessors in
their current form.

The use of the `Params` object is good.
Ultimately we should use the params object for everything, and to achive
it, we can use modules of param definitions (inlcluding validation).

This would centralise the validations, and ensure minimal duplication of
params across the API surface.