### PR TITLE
feat: add helper methods for authenticating MQTT websocket access

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -7,7 +7,7 @@ shards:
 
   action-controller:
     git: https://github.com/spider-gazelle/action-controller.git
-    version: 4.5.2
+    version: 4.6.0
 
   active-model:
     git: https://github.com/spider-gazelle/active-model.git

--- a/shard.lock
+++ b/shard.lock
@@ -151,7 +151,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 5.14.1
+    version: 5.14.2
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/shard.lock
+++ b/shard.lock
@@ -7,7 +7,7 @@ shards:
 
   action-controller:
     git: https://github.com/spider-gazelle/action-controller.git
-    version: 4.5.1
+    version: 4.5.2
 
   active-model:
     git: https://github.com/spider-gazelle/active-model.git

--- a/shard.lock
+++ b/shard.lock
@@ -47,7 +47,7 @@ shards:
 
   crystal-kcov:
     git: https://github.com/vici37/crystal-kcov.git
-    version: 0.1.0+git.commit.6c2191d080e01a49106b483cf0c4a0145e3f9090
+    version: 0.2.0+git.commit.d115c93879ef902ac8dda0a82704354e1cab902c
 
   db:
     git: https://github.com/crystal-lang/crystal-db.git
@@ -139,7 +139,7 @@ shards:
 
   placeos-driver:
     git: https://github.com/placeos/driver.git
-    version: 5.9.0
+    version: 5.9.8
 
   placeos-frontend-loader:
     git: https://github.com/placeos/frontend-loader.git

--- a/spec/controllers/mqtt_spec.cr
+++ b/spec/controllers/mqtt_spec.cr
@@ -1,0 +1,32 @@
+require "../helper"
+
+module PlaceOS::Api
+  describe MQTT do
+    with_server do
+      authenticated_user, authorization_header = authentication
+      base = Api::MQTT::NAMESPACE[0]
+
+      describe "MQTT Access" do
+        describe ".mqtt_acl_status" do
+          it "denies access for #{MQTT::MqttAcl::None} access" do
+            MQTT.mqtt_acl_status(MQTT::MqttAcl::None, authenticated_user).should eq HTTP::Status::FORBIDDEN
+          end
+
+          it "denies access for #{MQTT::MqttAcl::Deny} access" do
+            MQTT::MqttAcl
+              .values
+              .reject(MQTT::MqttAcl::Deny)
+              .map { |access| access | MQTT::MqttAcl::Deny }
+              .each do |access|
+                MQTT.mqtt_acl_status(access, authenticated_user).should eq HTTP::Status::FORBIDDEN
+              end
+          end
+
+          pending "allows #{MQTT::MqttAcl::Read} access"
+          pending "allows #{MQTT::MqttAcl::Write} access for support and above"
+          pending "denies #{MQTT::MqttAcl::Write} access"
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/mqtt_spec.cr
+++ b/spec/controllers/mqtt_spec.cr
@@ -3,8 +3,8 @@ require "../helper"
 module PlaceOS::Api
   describe MQTT do
     with_server do
-      scope = PlaceOS::Model::UserJWT::Scope.new("systems", :write)
-      authenticated_user, _scoped_authorization_header = authentication(scope: [scope])
+      scope = [PlaceOS::Model::UserJWT::Scope.new("mqtt", :write)]
+      authenticated_user, _scoped_authorization_header = authentication(scope: scope)
       user_jwt = PlaceOS::Model::Generator.jwt(authenticated_user, scope)
 
       describe "MQTT Access" do

--- a/spec/controllers/mqtt_spec.cr
+++ b/spec/controllers/mqtt_spec.cr
@@ -3,8 +3,7 @@ require "../helper"
 module PlaceOS::Api
   describe MQTT do
     with_server do
-      authenticated_user, authorization_header = authentication
-      base = Api::MQTT::NAMESPACE[0]
+      authenticated_user, _authorization_header = authentication
 
       describe "MQTT Access" do
         describe ".mqtt_acl_status" do

--- a/spec/controllers/root_spec.cr
+++ b/spec/controllers/root_spec.cr
@@ -3,7 +3,7 @@ require "../helper"
 module PlaceOS::Api
   describe Root do
     with_server do
-      authenticated_user, authorization_header = authentication
+      _authenticated_user, authorization_header = authentication
       base = Api::Root::NAMESPACE[0]
 
       it "responds to health checks" do

--- a/spec/controllers/root_spec.cr
+++ b/spec/controllers/root_spec.cr
@@ -100,28 +100,6 @@ module PlaceOS::Api
             end
           end
         end
-
-        context "MQTT Access" do
-          describe ".mqtt_acl_status" do
-            it "denies access for #{Root::MqttAcl::None} access" do
-              Root.mqtt_acl_status(Root::MqttAcl::None, authenticated_user).should eq HTTP::Status::FORBIDDEN
-            end
-
-            it "denies access for #{Root::MqttAcl::Deny} access" do
-              Root::MqttAcl
-                .values
-                .reject(Root::MqttAcl::Deny)
-                .map { |access| access | Root::MqttAcl::Deny }
-                .each do |access|
-                  Root.mqtt_acl_status(access, authenticated_user).should eq HTTP::Status::FORBIDDEN
-                end
-            end
-
-            pending "allows #{Root::MqttAcl::Read} access"
-            pending "allows #{Root::MqttAcl::Write} access for support and above"
-            pending "denies #{Root::MqttAcl::Write} access"
-          end
-        end
       end
     end
   end

--- a/src/placeos-rest-api/controllers/application.cr
+++ b/src/placeos-rest-api/controllers/application.cr
@@ -29,8 +29,9 @@ module PlaceOS::Api
     macro required_param(key)
       if (%value = {{ key }}).nil?
         return render_error(HTTP::Status::BAD_REQUEST, "Missing '{{ key }}' param")
+      else
+        %value
       end
-      %value
     end
 
     def boolean_param(key : String, default : Bool = false, allow_empty : Bool = false) : Bool

--- a/src/placeos-rest-api/controllers/application.cr
+++ b/src/placeos-rest-api/controllers/application.cr
@@ -74,10 +74,10 @@ module PlaceOS::Api
     before_action :set_request_id
 
     # All routes are authenticated, except root
-    before_action :authorize!, except: [:root]
+    before_action :authorize!, except: [:root, :mqtt_user, :mqtt_access]
 
     # Simplifies determining user's requests in server-side logs
-    before_action :set_user_id, except: [:root]
+    before_action :set_user_id, except: [:root, :mqtt_user, :mqtt_access]
 
     # Set user_id from parsed JWT
     def set_user_id

--- a/src/placeos-rest-api/controllers/mqtt.cr
+++ b/src/placeos-rest-api/controllers/mqtt.cr
@@ -31,8 +31,8 @@ module PlaceOS::Api
     # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)
     # example payload: acc=4&clientid=clientId-NwsUNfV30&topic=%2A
     post "/mqtt_access", :mqtt_access do
-      # we don't want to validate this as it may have expired,
-      # this is purely a permissions check for an established connection
+      # Skip validation of the JWT as it may have expired.
+      # This is acceptable as this route is a permission check for an established connection.
       mqtt_parse_jwt validate: false
 
       client_id = mqtt_client_id_param

--- a/src/placeos-rest-api/controllers/mqtt.cr
+++ b/src/placeos-rest-api/controllers/mqtt.cr
@@ -4,11 +4,6 @@ module PlaceOS::Api
   class MQTT < Application
     base "/api/engine/v2/mqtt/"
 
-    # Scopes
-    ###############################################################################################
-
-    before_action :can_read, only: [:mqtt_user, :mqtt_access]
-
     # Params
     ###############################################################################################
 
@@ -78,7 +73,9 @@ module PlaceOS::Api
         raise Error::Unauthorized.new("missing mqtt token")
       end
 
+      # Configure logging and check scope
       set_user_id
+      can_read
     end
 
     # Mosquitto MQTT broker accepts a flag enum for its ACL.

--- a/src/placeos-rest-api/controllers/mqtt.cr
+++ b/src/placeos-rest-api/controllers/mqtt.cr
@@ -48,8 +48,10 @@ module PlaceOS::Api
       head self.class.mqtt_acl_status(access, current_user)
     end
 
-    # MQTT Service can only communicate via Authorization header and
-    # we want to support both x-api-keys and jwt-tokens
+    # MQTT Service communicates via Authorization header.
+    # Supported authentication schemes...
+    # - x-api-key
+    # - JWTs
     protected def mqtt_parse_jwt(validate : Bool = true)
       if (auth = request.headers["Authorization"]?)
         case auth.count('.')

--- a/src/placeos-rest-api/controllers/mqtt.cr
+++ b/src/placeos-rest-api/controllers/mqtt.cr
@@ -102,6 +102,7 @@ module PlaceOS::Api
         HTTP::Status::FORBIDDEN
       when .write?
         if user.is_support?
+          can_write
           HTTP::Status::OK
         else
           Log.warn { "insufficient permissions" }

--- a/src/placeos-rest-api/controllers/mqtt.cr
+++ b/src/placeos-rest-api/controllers/mqtt.cr
@@ -23,14 +23,14 @@ module PlaceOS::Api
 
     # For MQTT JWT access: https://github.com/iegomez/mosquitto-go-auth#remote-mode
     # jwt_response_mode: status, jwt_params_mode: form
-    post "/mqtt_user", :mqtt_user do
+    post "/user", :mqtt_user do
       mqtt_parse_jwt
       head :ok
     end
 
     # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)
     # example payload: acc=4&clientid=clientId-NwsUNfV30&topic=%2A
-    post "/mqtt_access", :mqtt_access do
+    post "/access", :mqtt_access do
       # Skip validation of the JWT as it may have expired.
       # This is acceptable as this route is a permission check for an established connection.
       mqtt_parse_jwt validate: false

--- a/src/placeos-rest-api/controllers/mqtt.cr
+++ b/src/placeos-rest-api/controllers/mqtt.cr
@@ -56,7 +56,7 @@ module PlaceOS::Api
       unless (auth = request.headers["Authorization"]?)
         raise Error::Unauthorized.new("missing mqtt token")
       end
-    
+
       case auth.count('.')
       when 1 # work with x-api-key
         @user_token = Model::ApiKey.find_key!(auth.lchop("Bearer ").rstrip).build_jwt

--- a/src/placeos-rest-api/controllers/mqtt.cr
+++ b/src/placeos-rest-api/controllers/mqtt.cr
@@ -1,0 +1,119 @@
+require "./application"
+
+module PlaceOS::Api
+  class MQTT < Application
+    base "/api/engine/v2/mqtt/"
+
+    # Scopes
+    ###############################################################################################
+
+    before_action :can_read, only: [:mqtt_user, :mqtt_access]
+
+    # Params
+    ###############################################################################################
+
+    getter mqtt_client_id_param : String? do
+      params["clientid"]?
+    end
+
+    getter mqtt_topic_parma : String? do
+      params["topic"]?
+    end
+
+    getter mqtt_access_param : Int32? do
+      params["acc"]?.try(&.to_i?)
+    end
+
+    ###############################################################################################
+
+    # For MQTT JWT access: https://github.com/iegomez/mosquitto-go-auth#remote-mode
+    # jwt_response_mode: status, jwt_params_mode: form
+    post "/mqtt_user", :mqtt_user do
+      mqtt_parse_jwt
+      head :ok
+    end
+
+    # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)
+    # example payload: acc=4&clientid=clientId-NwsUNfV30&topic=%2A
+    post "/mqtt_access", :mqtt_access do
+      # we don't want to validate this as it may have expired,
+      # this is purely a permissions check for an established connection
+      mqtt_parse_jwt validate: false
+
+      client_id = mqtt_client_id_param
+      topic = required_param(mqtt_topic_parma)
+      access = MqttAcl.from_value(required_param(mqtt_access_param))
+
+      Log.context.set(
+        mqtt_client: client_id,
+        mqtt_topic: topic,
+        mqtt_access: access.to_s,
+      )
+
+      head self.class.mqtt_acl_status(access, current_user)
+    end
+
+    # MQTT Service can only communicate via Authorization header and
+    # we want to support both x-api-keys and jwt-tokens
+    protected def mqtt_parse_jwt(validate : Bool = true)
+      if (auth = request.headers["Authorization"]?)
+        case auth.count('.')
+        when 1 # work with x-api-key
+          @user_token = Model::ApiKey.find_key!(auth.lchop("Bearer ").rstrip).build_jwt
+        when 2 # work with jwt-token
+          unless (token = acquire_token)
+            raise Error::Unauthorized.new("missing mqtt token")
+          end
+
+          begin
+            @user_token = Model::UserJWT.decode(token, validate: validate)
+          rescue e : JWT::Error
+            Log.warn(exception: e) { {message: "bearer malformed", action: "mqtt_access"} }
+            raise Error::Unauthorized.new("bearer malformed")
+          end
+        else
+          raise Error::Unauthorized.new("missing mqtt token")
+        end
+      else
+        raise Error::Unauthorized.new("missing mqtt token")
+      end
+    ensure
+      set_user_id
+    end
+
+    # Mosquitto MQTT broker accepts a flag enum for its ACL.
+    # Source: https://github.com/iegomez/mosquitto-go-auth/blob/master/backends/constants/constants.go
+    @[Flags]
+    enum MqttAcl
+      Read      = 0x01
+      Write     = 0x02
+      Subscribe = 0x04
+      Deny      = 0x11
+    end
+
+    # Evaluate the ACL permissions flags of the JWT
+    # - Allows `read` to users
+    # - Allows `subscribe` to users
+    # - Denies `write` to users
+    # - Allows `write` to support users and above
+    # - Denies `deny` to all users
+    def self.mqtt_acl_status(access : MqttAcl, user) : HTTP::Status
+      case access
+      when .deny?, .none?
+        HTTP::Status::FORBIDDEN
+      when .write?
+        if user.is_support?
+          HTTP::Status::OK
+        else
+          Log.warn { "insufficient permissions" }
+          HTTP::Status::FORBIDDEN
+        end
+      when .read?, .subscribe?
+        HTTP::Status::OK
+      else
+        Log.warn { "unknown access level requested" }
+        HTTP::Status::BAD_REQUEST
+      end
+    end
+  end
+end

--- a/src/placeos-rest-api/controllers/mqtt.cr
+++ b/src/placeos-rest-api/controllers/mqtt.cr
@@ -77,7 +77,7 @@ module PlaceOS::Api
       else
         raise Error::Unauthorized.new("missing mqtt token")
       end
-    ensure
+
       set_user_id
     end
 

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -13,7 +13,22 @@ module PlaceOS::Api
   class Root < Application
     base "/api/engine/v2/"
 
-    before_action :check_admin, except: [:root, :healthz, :version, :signal, :cluster_version, :scopes, :mqtt_user, :mqtt_access]
+    before_action :check_admin, except: [
+      :cluster_version,
+      :healthz,
+      :mqtt_access,
+      :mqtt_user,
+      :root,
+      :scopes,
+      :signal,
+      :version,
+    ]
+
+    before_action :mqtt_parse_jwt, only: [
+      :mqtt_access,
+      :mqtt_user,
+    ]
+
     before_action :can_write_guest, only: [:signal]
 
     # Healthcheck
@@ -85,15 +100,19 @@ module PlaceOS::Api
       render json: Root.scopes
     end
 
-    protected def mqtt_parse_token
-      token = acquire_token
-      raise Error::Unauthorized.new unless token
+    # MQTT Access Control
+    ###############################################################################################
+
+    protected def mqtt_parse_jwt
+      unless (token = acquire_token)
+        raise Error::Unauthorized.new("missing mqtt token")
+      end
+
       begin
         @user_token = Model::UserJWT.decode(token)
       rescue e : JWT::Error
         Log.warn(exception: e) { {message: "bearer malformed", action: "mqtt_access"} }
-        # Request bearer was malformed
-        raise Error::Unauthorized.new "bearer malformed"
+        raise Error::Unauthorized.new("bearer malformed")
       end
     ensure
       set_user_id
@@ -102,39 +121,72 @@ module PlaceOS::Api
     # For MQTT JWT access: https://github.com/iegomez/mosquitto-go-auth#remote-mode
     # jwt_response_mode: status, jwt_params_mode: form
     post "/mqtt_user", :mqtt_user do
-      mqtt_parse_token
       head :ok
+    end
+
+    getter mqtt_client_id : String? do
+      params["clientid"]?
+    end
+
+    getter mqtt_topic : String? do
+      params["topic"]
+    end
+
+    getter mqtt_access : Int32? do
+      params["acc"]?.try(&.to_i?)
     end
 
     # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)
     post "/mqtt_access", :mqtt_access do
-      mqtt_parse_token
-      client = params["clientid"]
-      topic = params["topic"]
-      acc = params["acc"]
-      response = HTTP::Status::FORBIDDEN
-      error = nil
+      client_id = required_param(mqtt_client_id)
+      topic = required_param(mqtt_topic)
+      access = MqttAcl.from_value?(required_param(mqtt_access))
 
       Log.context.set(
-        mqtt_client: client,
+        mqtt_client: client_id,
         mqtt_topic: topic,
-        mqtt_access: acc
+        mqtt_access: access.to_s,
       )
 
-      case acc
-      when "1", "4" # read
-        response = HTTP::Status::OK
-      when "2", "3" # write
-        unless is_support?
-          error = "no write permissions"
-        end
-      else
-        error = "unknown access level requested: #{acc}"
-      end
-
-      Log.warn { error.to_s } if error
-      head response
+      head self.class.mqtt_acl_status(access, current_user)
     end
+
+    # Mosquitto MQTT broker accepts a flag enum for its ACL.
+    # Source: https://github.com/iegomez/mosquitto-go-auth/blob/master/backends/constants/constants.go
+    @[Flags]
+    enum MqttAcl
+      Read      = 0x01
+      Write     = 0x02
+      Subscribe = 0x04
+      Deny      = 0x11
+    end
+
+    # Evaluate the ACL permissions flags of the JWT
+    # - Allows `read` to users
+    # - Allows `subscribe` to users
+    # - Denies `write` to users
+    # - Allows `write` to support users and above
+    # - Denies `deny` to all users
+    def self.mqtt_acl_status(access : MqttAcl, user) : HTTP::Status
+      case access
+      when .deny?, .none?
+        HTTP::Status::FORBIDDEN
+      when .write?
+        if user.is_support?
+          HTTP::Status::OK
+        else
+          Log.warn { "insufficient permissions" }
+          HTTP::Status::FORBIDDEN
+        end
+      when .read?, .subscribe?
+        HTTP::Status::OK
+      else
+        Log.warn { "unknown access level requested" }
+        HTTP::Status::BAD_REQUEST
+      end
+    end
+
+    ###############################################################################################
 
     class_getter version : PlaceOS::Model::Version do
       PlaceOS::Model::Version.new(

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -124,7 +124,7 @@ module PlaceOS::Api
       head :ok
     end
 
-    getter mqtt_client_id_param: String? do
+    getter mqtt_client_id_param : String? do
       params["clientid"]?
     end
 

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -129,7 +129,7 @@ module PlaceOS::Api
     end
 
     getter mqtt_topic : String? do
-      params["topic"]
+      params["topic"]?
     end
 
     getter mqtt_access : Int32? do
@@ -138,7 +138,9 @@ module PlaceOS::Api
 
     # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)
     post "/mqtt_access", :mqtt_access do
-      client_id = required_param(mqtt_client_id)
+      Log.warn { "MQTT ACCESS REQUEST:\n#{request.body}" }
+
+      client_id = mqtt_client_id
       topic = required_param(mqtt_topic)
       access = MqttAcl.from_value?(required_param(mqtt_access))
 

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -16,8 +16,6 @@ module PlaceOS::Api
     before_action :check_admin, except: [
       :cluster_version,
       :healthz,
-      :mqtt_access,
-      :mqtt_user,
       :root,
       :scopes,
       :signal,
@@ -93,109 +91,6 @@ module PlaceOS::Api
 
     get "/scopes", :scopes do
       render json: Root.scopes
-    end
-
-    # MQTT Access Control
-    ###############################################################################################
-
-    protected def mqtt_parse_jwt(validate : Bool = true)
-      if (auth = request.headers["Authorization"]?)
-        case auth.count('.')
-        when 1 # work with x-api-key
-          @user_token = Model::ApiKey.find_key!(auth.lchop("Bearer ").rstrip).build_jwt
-        when 2 # work with jwt-token
-          unless (token = acquire_token)
-            raise Error::Unauthorized.new("missing mqtt token")
-          end
-
-          begin
-            @user_token = Model::UserJWT.decode(token, validate: validate)
-          rescue e : JWT::Error
-            Log.warn(exception: e) { {message: "bearer malformed", action: "mqtt_access"} }
-            raise Error::Unauthorized.new("bearer malformed")
-          end
-        else
-          raise Error::Unauthorized.new("missing mqtt token")
-        end
-      else
-        raise Error::Unauthorized.new("missing mqtt token")
-      end
-    ensure
-      set_user_id
-    end
-
-    # For MQTT JWT access: https://github.com/iegomez/mosquitto-go-auth#remote-mode
-    # jwt_response_mode: status, jwt_params_mode: form
-    post "/mqtt_user", :mqtt_user do
-      mqtt_parse_jwt
-      head :ok
-    end
-
-    getter mqtt_client_id_param : String? do
-      params["clientid"]?
-    end
-
-    getter mqtt_topic_parma : String? do
-      params["topic"]?
-    end
-
-    getter mqtt_access_param : Int32? do
-      params["acc"]?.try(&.to_i?)
-    end
-
-    # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)
-    # acc=4&clientid=clientId-NwsUNfV30&topic=%2A
-    post "/mqtt_access", :mqtt_access do
-      # we don't want to validate this as it may have expired,
-      # this is purely a permissions check for an established connection
-      mqtt_parse_jwt validate: false
-
-      client_id = mqtt_client_id_param
-      topic = required_param(mqtt_topic_parma)
-      access = MqttAcl.from_value(required_param(mqtt_access_param))
-
-      Log.context.set(
-        mqtt_client: client_id,
-        mqtt_topic: topic,
-        mqtt_access: access.to_s,
-      )
-
-      head self.class.mqtt_acl_status(access, current_user)
-    end
-
-    # Mosquitto MQTT broker accepts a flag enum for its ACL.
-    # Source: https://github.com/iegomez/mosquitto-go-auth/blob/master/backends/constants/constants.go
-    @[Flags]
-    enum MqttAcl
-      Read      = 0x01
-      Write     = 0x02
-      Subscribe = 0x04
-      Deny      = 0x11
-    end
-
-    # Evaluate the ACL permissions flags of the JWT
-    # - Allows `read` to users
-    # - Allows `subscribe` to users
-    # - Denies `write` to users
-    # - Allows `write` to support users and above
-    # - Denies `deny` to all users
-    def self.mqtt_acl_status(access : MqttAcl, user) : HTTP::Status
-      case access
-      when .deny?, .none?
-        HTTP::Status::FORBIDDEN
-      when .write?
-        if user.is_support?
-          HTTP::Status::OK
-        else
-          Log.warn { "insufficient permissions" }
-          HTTP::Status::FORBIDDEN
-        end
-      when .read?, .subscribe?
-        HTTP::Status::OK
-      else
-        Log.warn { "unknown access level requested" }
-        HTTP::Status::BAD_REQUEST
-      end
     end
 
     ###############################################################################################

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -138,7 +138,7 @@ module PlaceOS::Api
 
     # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)
     post "/mqtt_access", :mqtt_access do
-      Log.warn { "MQTT ACCESS REQUEST:\n#{request.body}" }
+      Log.warn { "MQTT ACCESS REQUEST:\n#{request.body.gets_to_end}" }
 
       client_id = mqtt_client_id
       topic = required_param(mqtt_topic)

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -138,7 +138,7 @@ module PlaceOS::Api
 
     # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)
     post "/mqtt_access", :mqtt_access do
-      Log.warn { "MQTT ACCESS REQUEST:\n#{request.body.gets_to_end}" }
+      Log.warn { "MQTT ACCESS REQUEST:\n#{request.body.try &.gets_to_end}" }
 
       client_id = mqtt_client_id
       topic = required_param(mqtt_topic)

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -89,7 +89,7 @@ module PlaceOS::Api
       token = acquire_token
       raise Error::Unauthorized.new unless token
       begin
-        @user_token = user_token = Model::UserJWT.decode(token)
+        @user_token = Model::UserJWT.decode(token)
       rescue e : JWT::Error
         Log.warn(exception: e) { {message: "bearer malformed", action: "mqtt_access"} }
         # Request bearer was malformed
@@ -102,13 +102,13 @@ module PlaceOS::Api
     # For MQTT JWT access: https://github.com/iegomez/mosquitto-go-auth#remote-mode
     # jwt_response_mode: status, jwt_params_mode: form
     post "/mqtt_user", :mqtt_user do
-      user_token = mqtt_parse_token
+      mqtt_parse_token
       head :ok
     end
 
     # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)
     post "/mqtt_access", :mqtt_access do
-      user_token = mqtt_parse_token
+      mqtt_parse_token
       client = params["clientid"]
       topic = params["topic"]
       acc = params["acc"]

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -137,10 +137,16 @@ module PlaceOS::Api
     end
 
     # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)
+    # acc=4&clientid=clientId-NwsUNfV30&topic=%2A
     post "/mqtt_access", :mqtt_access do
-      Log.warn { "MQTT ACCESS REQUEST:\n#{request.body.try &.gets_to_end}" }
-
       client_id = mqtt_client_id
+
+      begin
+        request.body.try &.rewind
+      rescue
+      end
+      Log.warn { "MQTT ACCESS REQUEST:\n  -> p: #{params.inspect}\n  -> b: #{request.body.try &.gets_to_end}" }
+
       topic = required_param(mqtt_topic)
       access = MqttAcl.from_value?(required_param(mqtt_access))
 

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -148,7 +148,7 @@ module PlaceOS::Api
       Log.warn { "MQTT ACCESS REQUEST:\n  -> p: #{params.inspect}\n  -> b: #{request.body.try &.gets_to_end}" }
 
       topic = required_param(mqtt_topic_parma)
-      access = MqttAcl.from_value?(required_param(mqtt_access_param))
+      access = MqttAcl.from_value(required_param(mqtt_access_param))
 
       Log.context.set(
         mqtt_client: client_id,

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -124,22 +124,22 @@ module PlaceOS::Api
       head :ok
     end
 
-    getter mqtt_client_id : String? do
+    getter mqtt_client_id_param: String? do
       params["clientid"]?
     end
 
-    getter mqtt_topic : String? do
+    getter mqtt_topic_parma : String? do
       params["topic"]?
     end
 
-    getter mqtt_access : Int32? do
+    getter mqtt_access_param : Int32? do
       params["acc"]?.try(&.to_i?)
     end
 
     # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)
     # acc=4&clientid=clientId-NwsUNfV30&topic=%2A
     post "/mqtt_access", :mqtt_access do
-      client_id = mqtt_client_id
+      client_id = mqtt_client_id_param
 
       begin
         request.body.try &.rewind
@@ -147,8 +147,8 @@ module PlaceOS::Api
       end
       Log.warn { "MQTT ACCESS REQUEST:\n  -> p: #{params.inspect}\n  -> b: #{request.body.try &.gets_to_end}" }
 
-      topic = required_param(mqtt_topic)
-      access = MqttAcl.from_value?(required_param(mqtt_access))
+      topic = required_param(mqtt_topic_parma)
+      access = MqttAcl.from_value?(required_param(mqtt_access_param))
 
       Log.context.set(
         mqtt_client: client_id,

--- a/src/placeos-rest-api/utilities/scopes.cr
+++ b/src/placeos-rest-api/utilities/scopes.cr
@@ -20,12 +20,8 @@ module PlaceOS::Api
     end
 
     def self.can_scopes_access!(user_token : UserJWT, scopes : Enumerable(String), access : Access)
-      has_access = false
-      scopes.each do |scope|
-        if can_scope_access?(user_token, scope, access)
-          has_access = true
-          break
-        end
+      has_access = scopes.any? do |scope|
+        can_scope_access?(user_token, scope, access)
       end
 
       unless has_access


### PR DESCRIPTION
see https://github.com/iegomez/mosquitto-go-auth#remote-mode for the very poor details on how this should be implemented.

@w-le the URLs are:

```yaml
jwt_getuser_uri: /api/engine/v2/mqtt/user
jwt_aclcheck_uri: /api/engine/v2/mqtt/access
```