### PR TITLE
refactor: mqtt permissions check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: push
 jobs:
   test:
-    uses: PlaceOS/.github/.github/workflows/containerised-test.yml@aea47e9
+    uses: PlaceOS/.github/.github/workflows/containerised-test.yml@main
 
   crystal-style:
     uses: PlaceOS/.github/.github/workflows/crystal-style.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: push
 jobs:
   test:
-    uses: PlaceOS/.github/.github/workflows/containerised-test.yml@main
+    uses: PlaceOS/.github/.github/workflows/containerised-test.yml@aea47e9
 
   crystal-style:
     uses: PlaceOS/.github/.github/workflows/crystal-style.yml@main

--- a/src/placeos-rest-api/controllers/application.cr
+++ b/src/placeos-rest-api/controllers/application.cr
@@ -29,8 +29,9 @@ module PlaceOS::Api
     macro required_param(key)
       if (%value = {{ key }}).nil?
         return render_error(HTTP::Status::BAD_REQUEST, "Missing '{{ key }}' param")
+      else
+        %value
       end
-      %value
     end
 
     def boolean_param(key : String, default : Bool = false, allow_empty : Bool = false) : Bool

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -157,7 +157,7 @@ module PlaceOS::Api
       )
 
       status = case access
-               in .deny?
+               in .deny?, .none?
                  HTTP::Status::FORBIDDEN
                in .write?
                  if is_support?

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -102,9 +102,10 @@ module PlaceOS::Api
 
     # MQTT Access Control
     ###############################################################################################
+
     protected def mqtt_parse_jwt
       unless (token = acquire_token)
-        raise Error::Unauthorized.new("Missing mqtt token")
+        raise Error::Unauthorized.new("missing mqtt token")
       end
 
       begin
@@ -156,8 +157,8 @@ module PlaceOS::Api
       )
 
       status = case access
-               in .read?, .subscribe?
-                 HTTP::Status::OK
+               in .deny?
+                 HTTP::Status::FORBIDDEN
                in .write?
                  if is_support?
                    HTTP::Status::OK
@@ -165,8 +166,8 @@ module PlaceOS::Api
                    Log.warn { "insufficient permissions" }
                    HTTP::Status::FORBIDDEN
                  end
-               in .deny?
-                 HTTP::Status::FORBIDDEN
+               in .read?, .subscribe?
+                 HTTP::Status::OK
                in Nil
                  Log.warn { "unknown access level requested" }
                  HTTP::Status::BAD_REQUEST

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -139,8 +139,8 @@ module PlaceOS::Api
       params["topic"]
     end
 
-    getter mqtt_access : String? do
-      params["acc"]?
+    getter mqtt_access : Int32? do
+      params["acc"]?.try(&.to_i?)
     end
 
     # Sends a form with the following params: topic, clientid, acc (1: read, 2: write, 3: readwrite, 4: subscribe)

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -158,13 +158,15 @@ module PlaceOS::Api
       status = case access
                in .read?, .subscribe?
                  HTTP::Status::OK
-               in .write?, .deny?
+               in .write?
                  if is_support?
                    HTTP::Status::OK
                  else
                    Log.warn { "insufficient permissions" }
                    HTTP::Status::FORBIDDEN
                  end
+               in .deny?
+                 HTTP::Status::FORBIDDEN
                in Nil
                  Log.warn { "unknown access level requested" }
                  HTTP::Status::BAD_REQUEST


### PR DESCRIPTION
Use a flag enum to represent the access control flags provided by the [mosquito go auth client](https://github.com/iegomez/mosquitto-go-auth/blob/master/backends/constants/constants.go)