### PR TITLE
feat(users controller): add support for user model soft delete

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -151,7 +151,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 5.15.2
+    version: 5.15.3
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -173,7 +173,7 @@ module PlaceOS::Api
 
     # Destroy user, revoke authentication.
     def destroy
-      if current_authority.internals["soft_delete"] == true
+      if current_authority.try &.internals["soft_delete"] == true
         user.deleted = true
         user.save
       else

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -40,6 +40,10 @@ module PlaceOS::Api
       params["authority_id"]?.presence || params["authority"]?.presence
     end
 
+    getter include_deleted : Bool do
+      params["include_deleted"]? == "true"
+    end
+
     ###############################################################################################
 
     getter user : Model::User { find_user }
@@ -120,7 +124,7 @@ module PlaceOS::Api
       elastic = Model::User.elastic
       query = elastic.query(params)
 
-      query.must_not({"deleted" => [true]})
+      query.must_not({"deleted" => [true]}) unless include_deleted
 
       if authority = authority_id
         query.filter({"authority_id" => [authority]})
@@ -169,7 +173,12 @@ module PlaceOS::Api
 
     # Destroy user, revoke authentication.
     def destroy
-      user.destroy
+      if current_authority.internals["soft_delete"] == true
+        user.deleted = true
+        user.save
+      else
+        user.destroy
+      end
       head :ok
     rescue e : Model::Error
       render_error(HTTP::Status::BAD_REQUEST, e.message)

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -124,7 +124,7 @@ module PlaceOS::Api
       elastic = Model::User.elastic
       query = elastic.query(params)
 
-      query.must_not({"deleted" => [true]}) unless include_deleted
+      query.must_not({"deleted" => [true]}) unless include_deleted?
 
       if authority = authority_id
         query.filter({"authority_id" => [authority]})

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -40,8 +40,8 @@ module PlaceOS::Api
       params["authority_id"]?.presence || params["authority"]?.presence
     end
 
-    getter include_deleted : Bool do
-      params["include_deleted"]? == "true"
+    getter? include_deleted : Bool do
+      boolean_param("include_deleted")
     end
 
     ###############################################################################################

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -173,7 +173,7 @@ module PlaceOS::Api
 
     # Destroy user, revoke authentication.
     def destroy
-      if current_authority.try &.internals["soft_delete"] == true
+      if current_authority.try &.internals["soft_delete"]? == true
         user.deleted = true
         user.save
       else


### PR DESCRIPTION
I should probably update the `auth` service to uncheck this flag if someone logs in with it set

NTT have requested this as they don't want the user models going away for resolving data elsewhere in the system, but they don't want the deleted users showing up in searches.

We're also building a driver to periodically sync the user models with Graph API in case users have been disabled at that level.