### PR TITLE
chore: remove `Enumerable#tally_by` implementation

### DIFF
--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -8,16 +8,6 @@ require "./modules"
 require "./settings"
 require "../websocket"
 
-# TODO: Remove after this PR is merged https://github.com/crystal-lang/crystal/pull/10922
-module Enumerable(T)
-  def tally_by(& : T -> U) : Hash(U, Int32) forall U
-    each_with_object(Hash(U, Int32).new) do |item, hash|
-      count = hash[value = yield item]?
-      hash[value] = count ? count + 1 : 1
-    end
-  end
-end
-
 module PlaceOS::Api
   class Systems < Application
     include Utils::CoreHelper


### PR DESCRIPTION
Redundant code as the code is in the standard library