### PR TITLE
fix: swallow channel errors in single document changefeeds

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -155,7 +155,7 @@ shards:
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git
-    version: 2.2.0
+    version: 2.3.0
 
   pool:
     git: https://github.com/ysbaddaden/pool.git

--- a/spec/controllers/drivers_spec.cr
+++ b/spec/controllers/drivers_spec.cr
@@ -107,8 +107,7 @@ module PlaceOS::Api
         response.success?.should be_true
 
         path = "#{base}#{driver.id.not_nil!}/recompile"
-        header = authorization_header.merge({"Content-Type" => "application/json"})
-        result = curl(
+        _result = curl(
           method: "POST",
           path: path,
           headers: authorization_header.merge({"Content-Type" => "application/json"}),

--- a/spec/controllers/settings_spec.cr
+++ b/spec/controllers/settings_spec.cr
@@ -65,21 +65,16 @@ module PlaceOS::Api
         end
 
         it "returns settings for a set of parent ids" do
-          sys = Model::Generator.control_system.save!
-          settings = [
-            Model::Generator.settings(encryption_level: Encryption::Level::None, control_system: sys),
-            Model::Generator.settings(encryption_level: Encryption::Level::Admin, control_system: sys),
-            Model::Generator.settings(encryption_level: Encryption::Level::NeverDisplay, control_system: sys),
-          ]
-          clear, admin, never_displayed = settings.map(&.save!)
+          systems = Array.new(2) { Model::Generator.control_system.save! }
 
-          sys2 = Model::Generator.control_system.save!
-          settings = [
-            Model::Generator.settings(encryption_level: Encryption::Level::None, control_system: sys2),
-            Model::Generator.settings(encryption_level: Encryption::Level::Admin, control_system: sys2),
-            Model::Generator.settings(encryption_level: Encryption::Level::NeverDisplay, control_system: sys2),
-          ]
-          clear, admin, never_displayed = settings.map(&.save!)
+          systems.map do |system|
+            {Encryption::Level::None, Encryption::Level::Admin, Encryption::Level::NeverDisplay}.map do |level|
+              Model::Generator.settings(encryption_level: level, control_system: system).save!
+            end
+          end
+
+          sys, sys2 = systems
+
           refresh_elastic(Model::Settings.table_name)
 
           result = curl(

--- a/spec/websocket/session_spec.cr
+++ b/spec/websocket/session_spec.cr
@@ -98,7 +98,7 @@ module PlaceOS::Api::WebSocket
           status_name = "nugget"
 
           id = rand(10).to_i64
-          results = test_websocket_api(base, authorization_header) do |ws, control_system, mod|
+          updates, _, _ = test_websocket_api(base, authorization_header) do |ws, control_system, mod|
             request = {
               id:          id,
               system_id:   control_system.id.as(String),
@@ -110,8 +110,6 @@ module PlaceOS::Api::WebSocket
             sleep 0.1
           end
 
-          updates, control_system, mod = results
-          expected_meta = {sys: control_system.id, mod: mod.custom_name, index: 1, name: status_name}
           # Check all messages received
           updates.size.should eq 1
           # Check for successful ignore response

--- a/src/placeos-rest-api/controllers/repositories.cr
+++ b/src/placeos-rest-api/controllers/repositories.cr
@@ -104,33 +104,8 @@ module PlaceOS::Api
       # Trigger a pull event
       repository.pull!
 
-      # Initiate changefeed on the document's commit_hash
-      changefeed = Model::Repository.changes(repository.id.as(String))
-      channel = Channel(Model::Repository?).new(1)
-
-      # Wait until the commit hash is not head with a timeout of 20 seconds
-      found_repo = begin
-        spawn do
-          update_event = changefeed.find do |event|
-            repo = event.value
-            repo.destroyed? || !repo.should_pull?
-          end
-          channel.send(update_event.try &.value)
-        end
-
-        select
-        when received = channel.receive?
-          received
-        when timeout(3.minutes)
-          Log.info { "timeout" }
-          raise "timeout for repository update"
-        end
-      rescue
-        nil
-      ensure
-        # Terminate the changefeed
-        changefeed.stop
-        channel.close
+      found_repo = Utils::Changefeeds.await_model_change(repository, 3.minutes) do |updated|
+        updated.destroyed? || !updated.should_pull?
       end
 
       unless found_repo.nil?

--- a/src/placeos-rest-api/utilities/changefeeds.cr
+++ b/src/placeos-rest-api/utilities/changefeeds.cr
@@ -1,0 +1,36 @@
+module PlaceOS::Api
+  module Utils::Changefeeds
+    def self.await_model_change(model : T, timeout : Time::Span = 20.second, &check : T -> Bool) forall T
+      changefeed = model.class.changes(model.id.as(String))
+      channel = Channel(T?).new(1)
+
+      begin
+        spawn do
+          found = changefeed.find do |event|
+            check.call(event.value)
+          end
+
+          begin
+            channel.send(found.try &.value)
+          rescue Channel::ClosedError
+          end
+        end
+
+        select
+        when received = channel.receive?
+          received
+        when timeout(timeout)
+          message = "timeout waiting for changes on #{T}"
+          Log.info { message }
+          raise message
+        end
+      rescue
+        nil
+      ensure
+        # Terminate the changefeed
+        changefeed.stop
+        channel.close
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Refactor and extract changefeeds on a single document into `Utils::Changefeeds.await_model_change(model : T, timeout, & : T -> Bool) : T? forall T`
- Tidy up some specs and resolve ameba issues

`Channel`s used in single document changefeeds would be closed on timeout, causing the final event to be sent on a closed channel, producing a verbose and innocuous error.