### PR TITLE
feat(controllers:root): add `/platform` to render platform metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN adduser \
 RUN apk update && \
     apk add --no-cache \
         ca-certificates \
+        curl \
     && \
     update-ca-certificates
 

--- a/spec/controllers/asset_spec.cr
+++ b/spec/controllers/asset_spec.cr
@@ -33,6 +33,7 @@ module PlaceOS::Api
       describe "CRUD operations", tags: "crud" do
         test_crd(klass: Model::Asset, controller_klass: Assets)
       end
+
       it "update" do
         asset = Model::Generator.asset.save!
         original_name = asset.name

--- a/spec/controllers/settings_spec.cr
+++ b/spec/controllers/settings_spec.cr
@@ -135,7 +135,7 @@ module PlaceOS::Api
         end
       end
 
-      describe "history" do
+      describe "/:id/history" do
         it "returns history for a master setting" do
           sys = Model::Generator.control_system.save!
 

--- a/spec/controllers/systems_spec.cr
+++ b/spec/controllers/systems_spec.cr
@@ -45,99 +45,101 @@ module PlaceOS::Api
       describe "index", tags: "search" do
         test_base_index(klass: Model::ControlSystem, controller_klass: Systems)
 
-        it "filters systems by zones" do
-          Model::ControlSystem.clear
+        context "query parameter" do
+          it "zone_id filters systems by zones" do
+            Model::ControlSystem.clear
 
-          num_systems = 5
+            num_systems = 5
 
-          zone = Model::Generator.zone.save!
-          zone_id = zone.id.as(String)
+            zone = Model::Generator.zone.save!
+            zone_id = zone.id.as(String)
 
-          systems = Array.new(size: num_systems) do
-            Model::Generator.control_system
-          end
+            systems = Array.new(size: num_systems) do
+              Model::Generator.control_system
+            end
 
-          # Add the zone to a subset of systems
-          expected_systems = systems.shuffle[0..2]
-          expected_systems.each do |sys|
-            sys.zones = [zone_id]
-          end
-          systems.each &.save!
+            # Add the zone to a subset of systems
+            expected_systems = systems.shuffle[0..2]
+            expected_systems.each do |sys|
+              sys.zones = [zone_id]
+            end
+            systems.each &.save!
 
-          expected_ids = expected_systems.compact_map(&.id)
-          total_ids = expected_ids.size
+            expected_ids = expected_systems.compact_map(&.id)
+            total_ids = expected_ids.size
 
-          params = HTTP::Params.encode({"zone_id" => zone_id})
-          path = "#{base}?#{params}"
+            params = HTTP::Params.encode({"zone_id" => zone_id})
+            path = "#{base}?#{params}"
 
-          refresh_elastic(Model::ControlSystem.table_name)
-          found = until_expected("GET", path, authorization_header) do |response|
-            returned_ids = Array(Hash(String, JSON::Any)).from_json(response.body).map(&.["id"].as_s)
-            (returned_ids | expected_ids).size == total_ids
-          end
-
-          found.should be_true
-        end
-
-        it "filters systems by email" do
-          Model::ControlSystem.clear
-          num_systems = 5
-
-          systems = Array.new(size: num_systems) do
-            Model::Generator.control_system
-          end
-
-          # Add the zone to a subset of systems
-          expected_systems = systems.shuffle[0..2]
-          systems.each &.save!
-
-          expected_emails = expected_systems.compact_map(&.email)
-          expected_ids = expected_systems.compact_map(&.id)
-
-          total_ids = expected_ids.size
-          params = HTTP::Params.encode({"email" => expected_emails.join(',')})
-          path = "#{base}?#{params}"
-
-          found = until_expected("GET", path, authorization_header) do |response|
             refresh_elastic(Model::ControlSystem.table_name)
-            returned_ids = Array(Hash(String, JSON::Any)).from_json(response.body).map(&.["id"].as_s)
-            (returned_ids | expected_ids).size == total_ids
+            found = until_expected("GET", path, authorization_header) do |response|
+              returned_ids = Array(Hash(String, JSON::Any)).from_json(response.body).map(&.["id"].as_s)
+              (returned_ids | expected_ids).size == total_ids
+            end
+
+            found.should be_true
           end
 
-          found.should be_true
-        end
+          it "email filters systems by email" do
+            Model::ControlSystem.clear
+            num_systems = 5
 
-        it "filters systems by modules" do
-          Model::ControlSystem.clear
-          num_systems = 5
+            systems = Array.new(size: num_systems) do
+              Model::Generator.control_system
+            end
 
-          mod = Model::Generator.module.save!
-          module_id = mod.id.as(String)
+            # Add the zone to a subset of systems
+            expected_systems = systems.shuffle[0..2]
+            systems.each &.save!
 
-          systems = Array.new(size: num_systems) do
-            Model::Generator.control_system
+            expected_emails = expected_systems.compact_map(&.email)
+            expected_ids = expected_systems.compact_map(&.id)
+
+            total_ids = expected_ids.size
+            params = HTTP::Params.encode({"email" => expected_emails.join(',')})
+            path = "#{base}?#{params}"
+
+            found = until_expected("GET", path, authorization_header) do |response|
+              refresh_elastic(Model::ControlSystem.table_name)
+              returned_ids = Array(Hash(String, JSON::Any)).from_json(response.body).map(&.["id"].as_s)
+              (returned_ids | expected_ids).size == total_ids
+            end
+
+            found.should be_true
           end
 
-          # Add the zone to a subset of systems
-          expected_systems = systems.shuffle[0..2]
-          expected_systems.each do |sys|
-            sys.modules = [module_id]
+          it "module_id filters systems by modules" do
+            Model::ControlSystem.clear
+            num_systems = 5
+
+            mod = Model::Generator.module.save!
+            module_id = mod.id.as(String)
+
+            systems = Array.new(size: num_systems) do
+              Model::Generator.control_system
+            end
+
+            # Add the zone to a subset of systems
+            expected_systems = systems.shuffle[0..2]
+            expected_systems.each do |sys|
+              sys.modules = [module_id]
+            end
+            systems.each &.save!
+
+            expected_ids = expected_systems.compact_map(&.id)
+            total_ids = expected_ids.size
+
+            params = HTTP::Params.encode({"module_id" => module_id})
+            path = "#{base}?#{params}"
+
+            found = until_expected("GET", path, authorization_header) do |response|
+              refresh_elastic(Model::ControlSystem.table_name)
+              returned_ids = Array(Hash(String, JSON::Any)).from_json(response.body).map(&.["id"].as_s)
+              (returned_ids | expected_ids).size == total_ids
+            end
+
+            found.should be_true
           end
-          systems.each &.save!
-
-          expected_ids = expected_systems.compact_map(&.id)
-          total_ids = expected_ids.size
-
-          params = HTTP::Params.encode({"module_id" => module_id})
-          path = "#{base}?#{params}"
-
-          found = until_expected("GET", path, authorization_header) do |response|
-            refresh_elastic(Model::ControlSystem.table_name)
-            returned_ids = Array(Hash(String, JSON::Any)).from_json(response.body).map(&.["id"].as_s)
-            (returned_ids | expected_ids).size == total_ids
-          end
-
-          found.should be_true
         end
       end
 

--- a/spec/controllers/triggers_spec.cr
+++ b/spec/controllers/triggers_spec.cr
@@ -77,6 +77,7 @@ module PlaceOS::Api
         end
       end
     end
+
     describe "scopes" do
       test_controller_scope(Triggers)
       test_update_write_scope(Triggers)

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -22,4 +22,23 @@ module PlaceOS::Api
   TRIGGERS_URI = URI.parse(ENV["TRIGGERS_URI"]? || "http://triggers:3000")
 
   PROD = ENV["SG_ENV"]?.try(&.downcase) == "production"
+
+  # CHANGELOG
+  #################################################################################################
+
+  CHANGELOG_URI = "https://raw.githubusercontent.com/PlaceOS/PlaceOS/nightly/CHANGELOG.md"
+
+  PLATFORM_VERSION = {{ env("PLACE_VERSION") || "DEV" }}
+
+  private BUILD_CHANGELOG = {{ !PLATFORM_VERSION.downcase.starts_with?("dev") }}
+
+  PLATFORM_CHANGELOG = fetch_platform_changelog(BUILD_CHANGELOG)
+
+  macro fetch_platform_changelog(build)
+    {% if build %}
+      {{ run("curl -L #{CHANGELOG_URI}") }}
+    {% else %}
+      "CHANGELOG is not generated for development builds"
+    {% end %}
+  end
 end

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -28,8 +28,9 @@ module PlaceOS::Api
 
   CHANGELOG_URI = "https://raw.githubusercontent.com/PlaceOS/PlaceOS/nightly/CHANGELOG.md"
 
-  PLATFORM_VERSION = {{ env("PLACE_VERSION") || "DEV" }}
+  PLATFORM_VERSION = {{ (env("PLACE_VERSION") || "DEV").lchop(PLACE_TAG_PREFIX) }}
 
+  private PLACE_TAG_PREFIX = "placeos-"
   private BUILD_CHANGELOG = {{ !PLATFORM_VERSION.downcase.starts_with?("dev") }}
 
   PLATFORM_CHANGELOG = fetch_platform_changelog(BUILD_CHANGELOG)

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -36,7 +36,7 @@ module PlaceOS::Api
 
   macro fetch_platform_changelog(build)
     {% if build %}
-      {{ run("curl -L #{CHANGELOG_URI}") }}
+      {{ system("curl --location #{CHANGELOG_URI}").stringify }}
     {% else %}
       "CHANGELOG is not generated for development builds"
     {% end %}

--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -72,14 +72,28 @@ module PlaceOS::Api
         .first?
     end
 
+    # Platform Information
+    ###############################################################################################
+
+    record(
+      PlatformInfo,
+      version : String = PLATFORM_VERSION,
+      changelog : String = PLATFORM_CHANGELOG,
+    ) do
+      include JSON::Serializable
+    end
+
+    get "/platform", :platform_info do
+      render json: Root.platform_info
+    end
+
+    class_getter platform_info : PlatformInfo = PlatformInfo.new
+
+    # Versions
     ###############################################################################################
 
     get "/version", :version do
       render json: Root.version
-    end
-
-    get "/cluster/versions", :cluster_version do
-      render json: Root.construct_versions
     end
 
     get "/cluster/versions", :cluster_version do


### PR DESCRIPTION
Adds `/platform` to the `Root` controller

```json
// GET /api/engine/v2/platform
{
  "version": "<platform-version",
  "changelog": "<markdown changelog>"
}
```

This does introduce a build time step where if `PLACE_VERSION` is defined (i.e. not `DEV`), an HTTP request to github is made.
This does not affect development builds but may slow down release builds.

Related https://github.com/PlaceOS/backoffice/issues/210