### PR TITLE
refactor(api): `put_redirect` to prevent manual  update redirect

### DIFF
--- a/src/placeos-rest-api/controllers/api_keys.cr
+++ b/src/placeos-rest-api/controllers/api_keys.cr
@@ -56,8 +56,7 @@ module PlaceOS::Api
       save_and_respond(current_api_key) { show }
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       save_and_respond(Model::ApiKey.from_json(self.body)) do |key|

--- a/src/placeos-rest-api/controllers/application.cr
+++ b/src/placeos-rest-api/controllers/application.cr
@@ -20,6 +20,9 @@ module PlaceOS::Api
     # Helpers for defining scope checks on controller actions
     include Utils::Scopes
 
+    # For want of route templating, this module exists
+    include Utils::PutRedirect
+
     # Core service discovery
     class_getter core_discovery : Discovery::Core { Discovery::Core.instance }
 

--- a/src/placeos-rest-api/controllers/authentications.cr
+++ b/src/placeos-rest-api/controllers/authentications.cr
@@ -54,8 +54,7 @@ module PlaceOS::Api
         save_and_respond current_auth
       end
 
-      # TODO: replace manual id with interpolated value from `id_param`
-      put "/:id", :update_alt { update }
+      put_redirect
 
       def create
         save_and_respond(Model::{{auth_type.id}}Authentication.from_json(self.body))

--- a/src/placeos-rest-api/controllers/brokers.cr
+++ b/src/placeos-rest-api/controllers/brokers.cr
@@ -41,8 +41,7 @@ module PlaceOS::Api
       save_and_respond current_broker.assign_attributes_from_json(self.body)
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       save_and_respond(Model::Broker.from_json(self.body))

--- a/src/placeos-rest-api/controllers/domains.cr
+++ b/src/placeos-rest-api/controllers/domains.cr
@@ -39,8 +39,7 @@ module PlaceOS::Api
       save_and_respond current_domain
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       save_and_respond(Model::Authority.from_json(self.body))

--- a/src/placeos-rest-api/controllers/drivers.cr
+++ b/src/placeos-rest-api/controllers/drivers.cr
@@ -65,8 +65,7 @@ module PlaceOS::Api
       save_and_respond current_driver
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       save_and_respond(Model::Driver.from_json(self.body))

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -67,8 +67,7 @@ module PlaceOS::Api
       save_and_respond current_edge
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       create_body = Model::Edge::CreateBody.from_json(self.body)

--- a/src/placeos-rest-api/controllers/metadata.cr
+++ b/src/placeos-rest-api/controllers/metadata.cr
@@ -125,7 +125,7 @@ module PlaceOS::Api
       end
     end
 
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def destroy
       if (metadata_name = name).nil?

--- a/src/placeos-rest-api/controllers/modules.cr
+++ b/src/placeos-rest-api/controllers/modules.cr
@@ -176,8 +176,7 @@ module PlaceOS::Api
       end
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       save_and_respond(Model::Module.from_json(self.body))

--- a/src/placeos-rest-api/controllers/oauth_applications.cr
+++ b/src/placeos-rest-api/controllers/oauth_applications.cr
@@ -52,8 +52,7 @@ module PlaceOS::Api
       save_and_respond current_app
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       save_and_respond(Model::DoorkeeperApplication.from_json(self.body))

--- a/src/placeos-rest-api/controllers/repositories.cr
+++ b/src/placeos-rest-api/controllers/repositories.cr
@@ -71,8 +71,7 @@ module PlaceOS::Api
       save_and_respond current_repo
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       save_and_respond(Model::Repository.from_json(self.body))

--- a/src/placeos-rest-api/controllers/schema.cr
+++ b/src/placeos-rest-api/controllers/schema.cr
@@ -31,8 +31,7 @@ module PlaceOS::Api
       save_and_respond(current_schema)
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       schema = Model::JsonSchema.from_json(self.body)

--- a/src/placeos-rest-api/controllers/settings.cr
+++ b/src/placeos-rest-api/controllers/settings.cr
@@ -66,8 +66,7 @@ module PlaceOS::Api
       save_and_respond(current_settings, &.decrypt_for!(current_user))
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       new_settings = Model::Settings.from_json(self.body)

--- a/src/placeos-rest-api/controllers/system-triggers.cr
+++ b/src/placeos-rest-api/controllers/system-triggers.cr
@@ -98,8 +98,7 @@ module PlaceOS::Api
       save_and_respond(current_sys_trig)
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:trig_id", :update_alt { update }
+    put_redirect
 
     def create
       model = Model::TriggerInstance.from_json(self.body)

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -206,8 +206,7 @@ module PlaceOS::Api
       save_and_respond(current_control_system)
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:sys_id", :update_alt { update }
+    put_redirect
 
     def create
       save_and_respond Model::ControlSystem.from_json(self.body)

--- a/src/placeos-rest-api/controllers/triggers.cr
+++ b/src/placeos-rest-api/controllers/triggers.cr
@@ -44,8 +44,7 @@ module PlaceOS::Api
       save_and_respond(current_trigger)
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       save_and_respond Model::Trigger.from_json(self.body)

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -168,8 +168,7 @@ module PlaceOS::Api
       save_and_respond user
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     # Destroy user, revoke authentication.
     def destroy

--- a/src/placeos-rest-api/controllers/zones.cr
+++ b/src/placeos-rest-api/controllers/zones.cr
@@ -100,8 +100,7 @@ module PlaceOS::Api
       save_and_respond current_zone
     end
 
-    # TODO: replace manual id with interpolated value from `id_param`
-    put "/:id", :update_alt { update }
+    put_redirect
 
     def create
       save_and_respond Model::Zone.from_json(self.body)

--- a/src/placeos-rest-api/utilities/put_redirect.cr
+++ b/src/placeos-rest-api/utilities/put_redirect.cr
@@ -1,0 +1,9 @@
+module PlaceOS::Api::Utils::PutRedirect
+  macro put_redirect
+    {% if @type.has_method?(:update) %}
+      put "/{{DEFAULT_PARAM_ID[@type.id] || :id}}", :update_alt { update }
+    {% else %}
+      {% raise "`update` is not present on #{@type.id}" %}
+    {% end %}
+  end
+end


### PR DESCRIPTION
**Description of the change**

Creates a macro, `put_redirect`, that handles the creation of a redirect of `PUT` to the `PATCH` route.

**Benefits**

DRY code

**Possible drawbacks**

The macro require updating when adding OpenAPI helpers, however this will be done in a single place, so I think it's an overall benefit