### PR TITLE
refactor(controllers): remove `find_<model>` from `current_<model>`

### DIFF
--- a/src/placeos-rest-api/controllers/api_keys.cr
+++ b/src/placeos-rest-api/controllers/api_keys.cr
@@ -26,7 +26,12 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_api_key : Model::ApiKey { find_api_key }
+    getter current_api_key : Model::ApiKey do
+      id = params["id"]
+      Log.context.set(api_key: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::ApiKey.find!(id, runopts: {"read_mode" => "majority"})
+    end
 
     ###############################################################################################
 
@@ -71,16 +76,6 @@ module PlaceOS::Api
 
     get "/inspect", :inspect_key do
       render json: authorize!
-    end
-
-    # Helpers
-    ###########################################################################
-
-    protected def find_api_key
-      id = params["id"]
-      Log.context.set(api_key: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::ApiKey.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/asset_instances.cr
+++ b/src/placeos-rest-api/controllers/asset_instances.cr
@@ -15,7 +15,16 @@ module PlaceOS::Api
 
     before_action :ensure_json, only: [:create]
 
-    getter current_instance : Model::AssetInstance { find_asset_inst }
+    ###########################################################################
+
+    getter current_instance : Model::AssetInstance do
+      id = params["id"]
+      Log.context.set(asset_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::AssetInstance.find!(id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###########################################################################
 
     def index
       elastic = Model::AssetInstance.elastic
@@ -42,16 +51,6 @@ module PlaceOS::Api
     def destroy
       current_instance.destroy # expires the cache in after callback
       head :ok
-    end
-
-    # Helpers
-    ###########################################################################
-
-    protected def find_asset_inst
-      id = params["id"]
-      Log.context.set(asset_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::AssetInstance.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/assets.cr
+++ b/src/placeos-rest-api/controllers/assets.cr
@@ -15,11 +15,23 @@ module PlaceOS::Api
 
     before_action :ensure_json, only: [:create]
 
-    getter current_asset : Model::Asset { find_asset }
+    # Params
+    ###############################################################################################
 
     getter parent_id : String? do
       params["parent_id"]?.presence || params["parent"]?.presence
     end
+
+    ###############################################################################################
+
+    getter current_asset : Model::Asset do
+      id = params["id"]
+      Log.context.set(asset_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::Asset.find!(id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###############################################################################################
 
     def index
       elastic = Model::Asset.elastic
@@ -62,16 +74,6 @@ module PlaceOS::Api
       set_collection_headers(instances.size, Model::AssetInstance.table_name)
 
       render json: instances
-    end
-
-    # Helpers
-    ###########################################################################
-
-    protected def find_asset
-      id = params["id"]
-      Log.context.set(asset_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::Asset.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/authentications.cr
+++ b/src/placeos-rest-api/controllers/authentications.cr
@@ -29,7 +29,14 @@ module PlaceOS::Api
 
       ###############################################################################################
 
-      getter current_auth : Model::{{auth_type.id}}Authentication { find_auth }
+      getter current_auth : Model::{{auth_type.id}}Authentication do
+        id = params["id"]
+        Log.context.set({{auth_type.id.underscore}}_id: id)
+        # Find will raise a 404 (not found) if there is an error
+        Model::{{auth_type.id}}Authentication.find!(id, runopts: {"read_mode" => "majority"})
+      end
+
+      ###############################################################################################
 
       def index
         elastic = Model::{{auth_type.id}}Authentication.elastic
@@ -63,16 +70,6 @@ module PlaceOS::Api
       def destroy
         current_auth.destroy
         head :ok
-      end
-
-      #  Helpers
-      ###########################################################################
-
-      protected def find_auth
-        id = params["id"]
-        Log.context.set({{auth_type.id.underscore}}_id: id)
-        # Find will raise a 404 (not found) if there is an error
-        Model::{{auth_type.id}}Authentication.find!(id, runopts: {"read_mode" => "majority"})
       end
     end
   {% end %}

--- a/src/placeos-rest-api/controllers/brokers.cr
+++ b/src/placeos-rest-api/controllers/brokers.cr
@@ -23,7 +23,14 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_broker : Model::Broker { find_broker }
+    getter current_broker : Model::Broker do
+      id = params["id"]
+      Log.context.set(broker_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::Broker.find!(id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###############################################################################################
 
     def index
       brokers = Model::Broker.all.to_a
@@ -50,16 +57,6 @@ module PlaceOS::Api
     def destroy
       current_broker.destroy
       head :ok
-    end
-
-    # Helpers
-    ############################################################################
-
-    protected def find_broker
-      id = params["id"]
-      Log.context.set(broker_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::Broker.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/domains.cr
+++ b/src/placeos-rest-api/controllers/domains.cr
@@ -21,7 +21,14 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_domain : Model::Authority { find_domain }
+    getter current_domain : Model::Authority do
+      id = params["id"]
+      Log.context.set(authority_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::Authority.find!(id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###############################################################################################
 
     def index
       elastic = Model::Authority.elastic
@@ -48,16 +55,6 @@ module PlaceOS::Api
     def destroy
       current_domain.destroy
       head :ok
-    end
-
-    #  Helpers
-    ###########################################################################
-
-    protected def find_domain
-      id = params["id"]
-      Log.context.set(authority_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::Authority.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/drivers.cr
+++ b/src/placeos-rest-api/controllers/drivers.cr
@@ -21,7 +21,14 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_driver : Model::Driver { find_driver }
+    getter current_driver : Model::Driver do
+      id = params["id"]
+      Log.context.set(driver_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::Driver.find!(id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###############################################################################################
 
     def index
       # Pick off role from HTTP params, render error if present and invalid
@@ -167,16 +174,6 @@ module PlaceOS::Api
       }).get
 
       result.to_h
-    end
-
-    #  Helpers
-    ###########################################################################
-
-    protected def find_driver
-      id = params["id"]
-      Log.context.set(driver_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::Driver.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -30,7 +30,14 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_edge : Model::Edge { find_edge }
+    getter current_edge : Model::Edge do
+      id = params["id"]
+      Log.context.set(edge_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::Edge.find!(id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###############################################################################################
 
     class_getter connection_manager : ConnectionManager { ConnectionManager.new(core_discovery) }
 
@@ -82,16 +89,6 @@ module PlaceOS::Api
     def destroy
       current_edge.destroy
       head :ok
-    end
-
-    # Helpers
-    ###########################################################################
-
-    protected def find_edge
-      id = params["id"]
-      Log.context.set(edge_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::Edge.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/metadata.cr
+++ b/src/placeos-rest-api/controllers/metadata.cr
@@ -39,7 +39,11 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_zone : Model::Zone { find_zone }
+    getter current_zone : Model::Zone do
+      Log.context.set(zone_id: parent_id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::Zone.find!(parent_id)
+    end
 
     ###############################################################################################
 
@@ -146,12 +150,6 @@ module PlaceOS::Api
       end.tap do |model|
         model.modified_by = current_user
       end
-    end
-
-    def find_zone
-      Log.context.set(zone_id: parent_id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::Zone.find!(parent_id)
     end
 
     # Fetch zones for system the current user has a role for

--- a/src/placeos-rest-api/controllers/modules.cr
+++ b/src/placeos-rest-api/controllers/modules.cr
@@ -44,7 +44,13 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_module : Model::Module { find_module }
+    getter current_module : Model::Module do
+      Log.context.set(module_id: module_id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::Module.find!(module_id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###############################################################################################
 
     private class IndexParams < Params
       attribute as_of : Int32?
@@ -312,15 +318,6 @@ module PlaceOS::Api
       id = mod.is_a?(String) ? mod : mod.id.as(String)
       storage = Driver::RedisStorage.new(id)
       key ? storage[key] : storage.to_h
-    end
-
-    # Helpers
-    ###############################################################################################
-
-    protected def find_module
-      Log.context.set(module_id: module_id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::Module.find!(module_id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/oauth_applications.cr
+++ b/src/placeos-rest-api/controllers/oauth_applications.cr
@@ -26,7 +26,14 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_app : Model::DoorkeeperApplication { find_app }
+    getter current_app : Model::DoorkeeperApplication do
+      id = params["id"]
+      Log.context.set(application_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::DoorkeeperApplication.find!(id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###############################################################################################
 
     def index
       elastic = Model::DoorkeeperApplication.elastic
@@ -61,16 +68,6 @@ module PlaceOS::Api
     def destroy
       current_app.destroy
       head :ok
-    end
-
-    #  Helpers
-    ###########################################################################
-
-    protected def find_app
-      id = params["id"]
-      Log.context.set(application_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::DoorkeeperApplication.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/schema.cr
+++ b/src/placeos-rest-api/controllers/schema.cr
@@ -14,7 +14,14 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_schema : Model::JsonSchema { find_schema }
+    getter current_schema : Model::JsonSchema do
+      id = params["id"]
+      Log.context.set(schema_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::JsonSchema.find!(id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###############################################################################################
 
     def index
       elastic = Model::JsonSchema.elastic
@@ -41,13 +48,6 @@ module PlaceOS::Api
     def destroy
       current_schema.destroy
       head :ok
-    end
-
-    protected def find_schema
-      id = params["id"]
-      Log.context.set(schema_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::JsonSchema.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/settings.cr
+++ b/src/placeos-rest-api/controllers/settings.cr
@@ -36,7 +36,12 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_settings : Model::Settings { find_settings }
+    getter current_settings : Model::Settings do
+      id = params["id"]
+      Log.context.set(settings_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::Settings.find!(id, runopts: {"read_mode" => "majority"})
+    end
 
     ###############################################################################################
 
@@ -127,13 +132,6 @@ module PlaceOS::Api
       collated = model.settings_hierarchy.reverse!
       collated.each &.decrypt_for!(user)
       collated
-    end
-
-    protected def find_settings
-      id = params["id"]
-      Log.context.set(settings_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::Settings.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/system-triggers.cr
+++ b/src/placeos-rest-api/controllers/system-triggers.cr
@@ -24,8 +24,21 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_sys_trig : Model::TriggerInstance { find_sys_trig }
-    getter current_system : Model::ControlSystem { find_system }
+    getter current_sys_trig : Model::TriggerInstance do
+      id = params["trig_id"]
+      Log.context.set(trigger_instance_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::TriggerInstance.find!(id, runopts: {"read_mode" => "majority"})
+    end
+
+    getter current_system : Model::ControlSystem do
+      id = params["sys_id"]
+      Log.context.set(control_system_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::ControlSystem.find!(id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###############################################################################################
 
     class IndexParams < Params
       attribute complete : Bool = true
@@ -135,20 +148,6 @@ module PlaceOS::Api
         },
         except: except,
       )
-    end
-
-    protected def find_system
-      id = params["sys_id"]
-      Log.context.set(control_system_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::ControlSystem.find!(id, runopts: {"read_mode" => "majority"})
-    end
-
-    protected def find_sys_trig
-      id = params["trig_id"]
-      Log.context.set(trigger_instance_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::TriggerInstance.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -89,7 +89,13 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_control_system : Model::ControlSystem { find_system }
+    getter current_control_system : Model::ControlSystem do
+      Log.context.set(control_system_id: control_system_id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::ControlSystem.find!(control_system_id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###############################################################################################
 
     # Websocket API session manager
     class_getter session_manager : WebSocket::Manager { WebSocket::Manager.new(core_discovery) }
@@ -453,12 +459,6 @@ module PlaceOS::Api
       Core::Client.client(uri: self.locate_module(module_id), request_id: request_id) do |client|
         yield client
       end
-    end
-
-    protected def find_system
-      Log.context.set(control_system_id: control_system_id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::ControlSystem.find!(control_system_id, runopts: {"read_mode" => "majority"})
     end
   end
 end

--- a/src/placeos-rest-api/controllers/triggers.cr
+++ b/src/placeos-rest-api/controllers/triggers.cr
@@ -22,7 +22,14 @@ module PlaceOS::Api
 
     ###############################################################################################
 
-    getter current_trigger : Model::Trigger { find_trigger }
+    getter current_trigger : Model::Trigger do
+      id = params["id"]
+      Log.context.set(trigger_id: id)
+      # Find will raise a 404 (not found) if there is an error
+      Model::Trigger.find!(id, runopts: {"read_mode" => "majority"})
+    end
+
+    ###############################################################################################
 
     def index
       elastic = Model::Trigger.elastic
@@ -62,16 +69,6 @@ module PlaceOS::Api
       set_collection_headers(instances.size, Model::TriggerInstance.table_name)
 
       render json: instances
-    end
-
-    # Helpers
-    ###########################################################################
-
-    protected def find_trigger
-      id = params["id"]
-      Log.context.set(trigger_id: id)
-      # Find will raise a 404 (not found) if there is an error
-      Model::Trigger.find!(id, runopts: {"read_mode" => "majority"})
     end
   end
 end


### PR DESCRIPTION
**Description of the change**

Small refactor that removes the unnecessary separation of the `current_<model>` and `find_<model>` methods that are very common across the surface of the API. 

**Benefits**

Less code.