### PR TITLE
feat(repositories): add releases endpoint

### DIFF
--- a/src/placeos-rest-api/controllers/repositories.cr
+++ b/src/placeos-rest-api/controllers/repositories.cr
@@ -212,5 +212,42 @@ module PlaceOS::Api
         end
       end
     end
+
+    get "/:id/releases", :releases do
+      releases = Api::Repositories.releases(
+        repository: current_repo,
+        request_id: request_id,
+      )
+
+      render json: releases
+    end
+
+    def self.releases(repository : Model::Repository, request_id : String)
+      case repository.repo_type
+      in .interface?
+        # Dial the frontends service
+        FrontendLoader::Client.client(request_id: request_id) do |frontends_client|
+          frontends_client.releases(repository.folder_name)
+        end
+      in .driver?
+        Log.info { {
+          message:       "can only get releases for interface repositories",
+          repository_id: repository.id,
+          folder_name:   repository.folder_name,
+          name:          repository.name,
+          type:          repository.repo_type.to_s,
+        } }
+      end.tap do |result|
+        if result.nil?
+          Log.info { {
+            message:       "failed to retrieve releases",
+            repository_id: repository.id,
+            folder_name:   repository.folder_name,
+            name:          repository.name,
+            type:          repository.repo_type.to_s,
+          } }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
**Description of the change**

Adds an endpoint in the repositories controller that returns releases for a given repo

**Benefits**

Now backoffice can access needed release information

**Applicable issues**

https://github.com/PlaceOS/backoffice/issues/255
