### PR TITLE
fix(controller/edges): include `x_api_token` in Edge creation response

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -179,7 +179,7 @@ shards:
 
   opentelemetry-instrumentation:
     git: https://github.com/place-labs/opentelemetry-instrumentation.cr.git
-    version: 0.2.9+git.commit.2bed74e37ba785bc89200189ddfd00edde3452cc
+    version: 0.2.5+git.commit.a11a3cc334ce10569ba74b4d86535ff718325125
 
   pars: # Overridden
     git: https://github.com/spider-gazelle/pars.git
@@ -195,7 +195,7 @@ shards:
 
   placeos-compiler:
     git: https://github.com/placeos/compiler.git
-    version: 4.9.1
+    version: 4.9.2
 
   placeos-core-client:
     git: https://github.com/placeos/core-client.git
@@ -207,19 +207,19 @@ shards:
 
   placeos-frontend-loader:
     git: https://github.com/placeos/frontend-loader.git
-    version: 2.1.0
+    version: 2.2.0
 
   placeos-log-backend:
     git: https://github.com/place-labs/log-backend.git
-    version: 0.8.10
+    version: 0.8.12
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 8.4.1
+    version: 8.5.0
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git
-    version: 2.5.0
+    version: 2.5.3
 
   pool:
     git: https://github.com/ysbaddaden/pool.git
@@ -271,7 +271,7 @@ shards:
 
   search-ingest:
     git: https://github.com/placeos/search-ingest.git
-    version: 2.1.6
+    version: 2.3.3
 
   secrets-env: # Overridden
     git: https://github.com/spider-gazelle/secrets-env.git

--- a/spec/controllers/edges_spec.cr
+++ b/spec/controllers/edges_spec.cr
@@ -14,6 +14,21 @@ module PlaceOS::Api
 
       describe "CRUD operations", tags: "crud" do
         Specs.test_crd(Model::Edge, Edges)
+
+        describe "create" do
+          it "contains the api token in the response" do
+            result = curl(
+              method: "POST",
+              path: base,
+              body: {
+                "description" => "",
+                "name" => "test-edge"
+              }.to_json,
+              headers: authorization_header.merge({"Content-Type" => "application/json"}),
+            )
+            result.body.should contain "x_api_key"
+          end
+        end
       end
 
       describe "scopes" do

--- a/spec/controllers/edges_spec.cr
+++ b/spec/controllers/edges_spec.cr
@@ -22,7 +22,7 @@ module PlaceOS::Api
               path: base,
               body: {
                 "description" => "",
-                "name" => "test-edge"
+                "name"        => "test-edge",
               }.to_json,
               headers: authorization_header.merge({"Content-Type" => "application/json"}),
             )

--- a/spec/controllers/edges_spec.cr
+++ b/spec/controllers/edges_spec.cr
@@ -26,7 +26,8 @@ module PlaceOS::Api
               }.to_json,
               headers: authorization_header.merge({"Content-Type" => "application/json"}),
             )
-            result.body.should contain "x_api_key"
+
+            JSON.parse(result.body)["x_api_key"]?.try(&.as_s?).should_not be_nil
           end
         end
       end

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -79,11 +79,19 @@ module PlaceOS::Api
     def create
       create_body = Model::Edge::CreateBody.from_json(self.body)
       user = Model::User.find!(create_body.user_id || current_user.id.as(String))
-      save_and_respond(Model::Edge.for_user(
+      new_edge = Model::Edge.for_user(
         user: user,
         name: create_body.name,
-        description: create_body.description,
-      ))
+        description: create_body.description
+      )
+
+      # Ensure instance variable initialised
+      new_edge.x_api_key
+
+      _result, status = save_and_status(new_edge)  
+      render_json(status) do |json|
+        new_edge.to_key_json(json)
+      end
     end
 
     def destroy

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -88,7 +88,7 @@ module PlaceOS::Api
       # Ensure instance variable initialised
       new_edge.x_api_key
 
-      _result, status = save_and_status(new_edge)  
+      _result, status = save_and_status(new_edge)
       render_json(status) do |json|
         new_edge.to_key_json(json)
       end


### PR DESCRIPTION
**Description of the change**

Ensure that the api token is included in the response when creating a new edge while also ensuring it does not persist.

**Benefits**

Backoffice (and any other UI) can now display the api token to the user when creating a new edge.