### PR TITLE
feat(controller/metadata): add pagination for `query` route

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -215,7 +215,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 8.5.0
+    version: 8.6.0
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/shard.lock
+++ b/shard.lock
@@ -215,7 +215,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 8.6.0
+    version: 8.7.0
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/src/placeos-rest-api/controllers/application.cr
+++ b/src/placeos-rest-api/controllers/application.cr
@@ -58,9 +58,8 @@ module PlaceOS::Api
       response.headers["Content-Range"] = "#{item_type} #{range_start}-#{range_end}/#{total_items}"
 
       if range_end < total_items
-        params["offset"] = (range_end + 1).to_s
-        params["limit"] = query.limit.to_s
-        query_params = params.join('&') { |key, value| "#{key}=#{value}" }
+        query_params["offset"] = (range_end + 1).to_s
+        query_params["limit"] = query.limit.to_s
         response.headers["Link"] = %(<#{route}?#{query_params}>; rel="next")
       end
 

--- a/src/placeos-rest-api/controllers/metadata.cr
+++ b/src/placeos-rest-api/controllers/metadata.cr
@@ -38,7 +38,7 @@ module PlaceOS::Api
     end
 
     getter limit : Int32 do
-      params["limit"]?.try(&.to_i?) || 15
+      params["limit"]?.try(&.to_i?) || 100
     end
 
     getter? include_parent : Bool do
@@ -56,19 +56,16 @@ module PlaceOS::Api
     ###############################################################################################
 
     def index
+      # Construct the queries from the URI parameters
       queries = query_params.compact_map do |key, value|
         Model::Metadata::Query.from_param?(key, value.presence)
       end
 
-      results = Model::Metadata.query(queries)
+      results = Model::Metadata.query(queries, offset, limit)
+
       total = results.size
-
-      # TODO: Add pagination to `Metadata#index`
-      # range_start = offset
-      # range_end = (results.size || 0) + range_start
-
-      range_start = 0
-      range_end = total
+      range_start = offset
+      range_end = total + range_start
 
       response.headers["X-Total-Count"] = total.to_s
       response.headers["Content-Range"] = "metadata #{range_start}-#{range_end}/#{total}"

--- a/src/placeos-rest-api/controllers/metadata.cr
+++ b/src/placeos-rest-api/controllers/metadata.cr
@@ -62,19 +62,10 @@ module PlaceOS::Api
       end
 
       # TODO: Use destructure after `spider-gazelle/promise` is fixed
-      data = Promise.all(
-        Promise.defer { Model::Metadata.query(queries, offset, limit) },
-        Promise.defer { Model::Metadata.query_count(queries) },
-      ).get
-
-      total = 0
-      results = Array(Model::Metadata).new(initial_capacity: 0)
-      data.each do |element|
-        case element
-        in Int32                  then total = element
-        in Array(Model::Metadata) then results = element
-        end
-      end
+      query_promise = Promise.defer { Model::Metadata.query(queries, offset, limit) }
+      query_count_promise = Promise.defer { Model::Metadata.query_count(queries) }
+      results = query_promise.get
+      total = query_count_promise.get
 
       range_end = results.size + offset
 


### PR DESCRIPTION
**Description of the change**

Adds pagination via `offset` and `limit` parameters to `GET ../metadata`

**Benefits**

Pagination of potentially large query results.

**Possible drawbacks**

Users of previous versions may expect all results to be returned.
However, the `Link` header will be set if there are further results in a query

**Applicable issues**

- Resolves #263 