### PR TITLE
test(edge): authentication of edge client with the API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       ALLOW_NONE_AUTHENTICATION: "yes"
 
   redis:
-    image: eqalpha/keydb
+    image: eqalpha/keydb:alpine
     restart: always
     hostname: redis
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ x-search-ingest-client-env: &search-ingest-client-env
 
 services:
   test: # Rest API
-    image: placeos/service-spec-runner:${CRYSTAL_VERSION:-1.3.2}
+    image: placeos/service-spec-runner:${CRYSTAL_VERSION:-1.4.1}
     volumes:
       - ${PWD}/spec:/app/spec
       - ${PWD}/src:/app/src

--- a/shard.lock
+++ b/shard.lock
@@ -29,6 +29,10 @@ shards:
     git: https://github.com/spider-gazelle/bindata.git
     version: 1.10.0
 
+  clustering:
+    git: https://github.com/place-labs/clustering.git
+    version: 3.1.1
+
   connect-proxy:
     git: https://github.com/spider-gazelle/connect-proxy.git
     version: 2.0.0
@@ -95,11 +99,15 @@ shards:
 
   git-repository:
     git: https://github.com/place-labs/git-repository.git
-    version: 1.2.0
+    version: 1.3.0
 
   habitat:
     git: https://github.com/luckyframework/habitat.git
     version: 0.4.7
+
+  hardware:
+    git: https://github.com/crystal-community/hardware.git
+    version: 0.5.2
 
   hound-dog:
     git: https://github.com/place-labs/hound-dog.git
@@ -155,7 +163,7 @@ shards:
 
   opentelemetry-instrumentation:
     git: https://github.com/wyhaines/opentelemetry-instrumentation.cr.git
-    version: 0.3.1+git.commit.d4bd9afb7c28616b081b05978d836fd1c873ab75
+    version: 0.3.1+git.commit.e07ff4e1497b20526f65dc4b6a953dc231a80d2c
 
   pars: # Overridden
     git: https://github.com/spider-gazelle/pars.git
@@ -172,6 +180,10 @@ shards:
   placeos-compiler:
     git: https://github.com/placeos/compiler.git
     version: 4.9.2
+
+  placeos-core:
+    git: https://github.com/placeos/core.git
+    version: 4.3.0+git.commit.5a3f8f5aa8f1bdda64cbb2ec181c2ae4273a87ed
 
   placeos-core-client:
     git: https://github.com/placeos/core-client.git

--- a/shard.lock
+++ b/shard.lock
@@ -183,7 +183,7 @@ shards:
 
   placeos-core:
     git: https://github.com/placeos/core.git
-    version: 4.3.0+git.commit.5a3f8f5aa8f1bdda64cbb2ec181c2ae4273a87ed
+    version: 4.3.1+git.commit.8217a54b4ad8a5b84452a89f5f2385910d4561d6
 
   placeos-core-client:
     git: https://github.com/placeos/core-client.git

--- a/shard.yml
+++ b/shard.yml
@@ -126,4 +126,8 @@ development_dependencies:
   # required for specs (core_helper)
   placeos-compiler:
     github: placeos/compiler
-    version: ~> 4.9
+    version: ">= 4.9"
+
+  placeos-core:
+    github: placeos/core
+    branch: master

--- a/spec/controllers/edges_spec.cr
+++ b/spec/controllers/edges_spec.cr
@@ -1,6 +1,10 @@
 require "../helper"
+require "placeos-core/placeos-edge/client"
 
 module PlaceOS::Api
+  TEST_EDGE_JSON = "{\"name\":\"Test Edge\",\"description\":\"A test edge\"}"
+  TEST_LOCAL_HOST = "localhost"
+  TEST_LOCAL_PORT = 6000
   describe Edges do
     _authenticated_user, authorization_header = authentication
     base = Edges::NAMESPACE[0]
@@ -10,6 +14,34 @@ module PlaceOS::Api
 
       describe "index", tags: "search" do
         Specs.test_base_index(Model::Edge, Edges)
+      end
+
+      describe "control" do
+        it "authenticates with an API key from a new edge" do
+          # First create a new edge to test with as the countroller would
+          create_body = Model::Edge::CreateBody.from_json(TEST_EDGE_JSON)
+          new_edge = Model::Edge.for_user(
+            user: _authenticated_user,
+            name: create_body.name,
+            description: create_body.description
+          )
+
+          # Ensure instance variable initialised and edge saved
+          new_edge.x_api_key
+          new_edge.save!
+          
+          uri = URI.new(host: TEST_LOCAL_HOST)
+          uri.port = TEST_LOCAL_PORT
+          uri.query = "api-key=#{new_edge.x_api_key}"
+          client = PlaceOS::Edge::Client.new(
+            uri: uri,
+            secret: new_edge.x_api_key
+          )
+          client.connect do
+            client.transport.closed?.should_not be_nil
+            client.disconnect          
+          end
+        end
       end
 
       describe "CRUD operations", tags: "crud" do

--- a/spec/controllers/edges_spec.cr
+++ b/spec/controllers/edges_spec.cr
@@ -13,11 +13,10 @@ module PlaceOS::Api
         Specs.test_base_index(Model::Edge, Edges)
       end
 
-      describe "control" do
+      describe "/control" do
         it "authenticates with an API key from a new edge" do
-          # First create a new edge to test with as the countroller would
+          # Create a new edge to test with as the controller would
           edge_name = "Test Edge"
-
           edge_host = "localhost"
           edge_port = 6000
 

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -10,7 +10,7 @@ module PlaceOS::Api
     # Scopes
     ###############################################################################################
 
-    generate_scope_check "edge-control"
+    generate_scope_check ::PlaceOS::Model::Edge::CONTROL_SCOPE
 
     before_action :can_read, only: [:index, :show]
     before_action :can_write, only: [:create, :update, :destroy, :remove, :update_alt]

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -10,7 +10,7 @@ module PlaceOS::Api
     # Scopes
     ###############################################################################################
 
-    generate_scope_check ::PlaceOS::Model::Edge::CONTROL_SCOPE
+    generate_scope_check(::PlaceOS::Model::Edge::CONTROL_SCOPE)
 
     before_action :can_read, only: [:index, :show]
     before_action :can_write, only: [:create, :update, :destroy, :remove, :update_alt]

--- a/src/placeos-rest-api/controllers/edges.cr
+++ b/src/placeos-rest-api/controllers/edges.cr
@@ -10,7 +10,7 @@ module PlaceOS::Api
     # Scopes
     ###############################################################################################
 
-    generate_scope_check(Model::Edge::CONTROL_SCOPE)
+    generate_scope_check "edge-control"
 
     before_action :can_read, only: [:index, :show]
     before_action :can_write, only: [:create, :update, :destroy, :remove, :update_alt]


### PR DESCRIPTION
**Description of the change**

Update the edge controller to generate scope methods using a string as the constant previously used is not available before runtime when the macro runs.

Also add a spec which tests authentication against the real edge control endpoint.

**Benefits**

Edge client can authenticate against the websocket control endpoint.