### PR TITLE
feat: add metadata change signaling

### DIFF
--- a/src/placeos-rest-api/controllers/root.cr
+++ b/src/placeos-rest-api/controllers/root.cr
@@ -195,7 +195,7 @@ module PlaceOS::Api
                 end
 
       path = Path["placeos/"].join(channel).to_s
-      Log.info { "signalling #{path} with #{payload.size} bytes" }
+      Log.info { "signalling #{path} with #{payload.bytesize} bytes" }
 
       ::PlaceOS::Driver::RedisStorage.with_redis &.publish(path, payload)
       head :ok

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -219,7 +219,9 @@ module PlaceOS::Api
     end
 
     def destroy
+      cs_id = current_control_system.id
       current_control_system.destroy
+      spawn { Api::Metadata.signal_metadata(:destroy_all, {parent_id: cs_id}) }
       head :ok
     end
 

--- a/src/placeos-rest-api/controllers/users.cr
+++ b/src/placeos-rest-api/controllers/users.cr
@@ -228,7 +228,9 @@ module PlaceOS::Api
         user.deleted = true
         user.save
       else
+        user_id = user.id
         user.destroy
+        spawn { Api::Metadata.signal_metadata(:destroy_all, {parent_id: user_id}) }
       end
       head :ok
     rescue e : Model::Error

--- a/src/placeos-rest-api/controllers/zones.cr
+++ b/src/placeos-rest-api/controllers/zones.cr
@@ -114,7 +114,9 @@ module PlaceOS::Api
     end
 
     def destroy
+      zone_id = current_zone.id
       current_zone.destroy
+      spawn { Api::Metadata.signal_metadata(:destroy_all, {parent_id: zone_id}) }
       head :ok
     end
 


### PR DESCRIPTION
signals on `metadata/changed`
```yaml
{
  # possible actions: update, destroy, destroy_all
  "action": "update",
  # same as what you see when you query a metadata name
  "metadata": {
    "parent_id": "user-123456"
  }
}
```

* destroy_all only provides the `metadata.parent_id`, all metadata keys have been deleted
* destroy only provides `metadata.parent_id` and `metadata.name` (single key deleted)
* update provides the full metadata model