### PR TITLE
chore(shard.lock): bump dependencies

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -7,15 +7,15 @@ shards:
 
   action-controller:
     git: https://github.com/spider-gazelle/action-controller.git
-    version: 5.4.1
+    version: 5.4.2
 
   active-model:
     git: https://github.com/spider-gazelle/active-model.git
-    version: 4.2.2
+    version: 4.2.3
 
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.1.0
+    version: 1.2.0
 
   any_hash:
     git: https://github.com/sija/any_hash.cr.git
@@ -203,7 +203,7 @@ shards:
 
   placeos-core:
     git: https://github.com/placeos/core.git
-    version: 4.6.3+git.commit.5ac348f1bba64e1bfcd619902e1189ca35ec5335
+    version: 4.7.0+git.commit.665a6536cc7763ff9a798571b1e6c0f7d9a333ee
 
   placeos-core-client: # Overridden
     git: https://github.com/placeos/core-client.git
@@ -215,7 +215,7 @@ shards:
 
   placeos-frontend-loader:
     git: https://github.com/placeos/frontend-loader.git
-    version: 2.5.3
+    version: 2.6.0
 
   placeos-log-backend:
     git: https://github.com/place-labs/log-backend.git


### PR DESCRIPTION
fixes active model not applying defaults in assignement when updating a model via assignment helpers