### PR TITLE
fix(systems): prevent bypass of email downcase

### DIFF
--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -51,12 +51,12 @@ module PlaceOS::Api
     getter! current_control_system : ::PlaceOS::Model::ControlSystem
 
     @[AC::Route::Filter(:before_action, only: [:update, :create], body: :control_system_update)]
-    def parse_update_control_system(@control_system_update : ::PlaceOS::Model::ControlSystem)
-      return unless system = @control_system_update
+    def parse_update_control_system(control_system : ::PlaceOS::Model::ControlSystem)
       # prevent bypass of email initialisation
-      if email = system.email
-        system.email = ::PlaceOS::Model::Email.new(email.to_s)
+      if email = control_system.email
+        control_system.email = ::PlaceOS::Model::Email.new(email.to_s)
       end
+      @control_system_update = control_system
     end
 
     getter! control_system_update : ::PlaceOS::Model::ControlSystem

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -52,6 +52,11 @@ module PlaceOS::Api
 
     @[AC::Route::Filter(:before_action, only: [:update, :create], body: :control_system_update)]
     def parse_update_control_system(@control_system_update : ::PlaceOS::Model::ControlSystem)
+      return unless system = @control_system_update
+      # prevent bypass of email initialisation
+      if email = system.email
+        system.email = ::PlaceOS::Model::Email.new(email.to_s)
+      end
     end
 
     getter! control_system_update : ::PlaceOS::Model::ControlSystem

--- a/src/placeos-rest-api/controllers/systems.cr
+++ b/src/placeos-rest-api/controllers/systems.cr
@@ -50,7 +50,7 @@ module PlaceOS::Api
 
     getter! current_control_system : ::PlaceOS::Model::ControlSystem
 
-    @[AC::Route::Filter(:before_action, only: [:update, :create], body: :control_system_update)]
+    @[AC::Route::Filter(:before_action, only: [:update, :create], body: :control_system)]
     def parse_update_control_system(control_system : ::PlaceOS::Model::ControlSystem)
       # prevent bypass of email initialisation
       if email = control_system.email


### PR DESCRIPTION
Avoid bypassing email initialize method to ensure email is downcased

- fixes https://github.com/PlaceOS/rest-api/issues/401
