### PR TITLE
feat: Add filtering by tags to metadata children method

### DIFF
--- a/OPENAPI_DOC.yml
+++ b/OPENAPI_DOC.yml
@@ -10757,7 +10757,9 @@ paths:
 
         Filter for a specific metadata by name via `name` param.
 
-        Includes the parent metadata by default via `include_parent` param.'
+        Includes the parent metadata by default via `include_parent` param.
+        
+        Filter zones by tags via `tags` param.'
       tags:
       - Metadata
       operationId: PlaceOS::Api::Metadata_children_metadata
@@ -10781,6 +10783,14 @@ paths:
         schema:
           type: string
           nullable: true
+      - name: tags
+        in: query
+        description: return zones with particular tags
+        example: building,level
+        schema:
+          type: array
+          items:
+            type: string
       responses:
         200:
           description: OK

--- a/test
+++ b/test
@@ -5,7 +5,7 @@ set -eu
 # this function is called when Ctrl-C is sent
 function trap_ctrlc ()
 {
-    docker compose down &> /dev/null
+    docker-compose down &> /dev/null
     exit 2
 }
 
@@ -13,17 +13,17 @@ function trap_ctrlc ()
 # when signal 2 (SIGINT) is received
 trap "trap_ctrlc" 2
 
-docker compose pull
+docker-compose pull
 
-docker compose build
+docker-compose build
 
 exit_code="0"
 
-docker compose run \
+docker-compose run \
         --rm \
         test "$@" \
     || exit_code="$?"
 
-docker compose down &> /dev/null
+docker-compose down &> /dev/null
 
 exit ${exit_code}

--- a/test
+++ b/test
@@ -5,7 +5,7 @@ set -eu
 # this function is called when Ctrl-C is sent
 function trap_ctrlc ()
 {
-    docker-compose down &> /dev/null
+    docker compose down &> /dev/null
     exit 2
 }
 
@@ -13,17 +13,17 @@ function trap_ctrlc ()
 # when signal 2 (SIGINT) is received
 trap "trap_ctrlc" 2
 
-docker-compose pull
+docker compose pull
 
-docker-compose build
+docker compose build
 
 exit_code="0"
 
-docker-compose run \
+docker compose run \
         --rm \
         test "$@" \
     || exit_code="$?"
 
-docker-compose down &> /dev/null
+docker compose down &> /dev/null
 
 exit ${exit_code}


### PR DESCRIPTION
To grab all building zones in an org along with their metadata you have to pull all the children zones (and their metadata) of an org and then select the ones with building tags.

This is just a simple change to allow for only grabbing children zones and metadata with a specific tag.

 