### PR TITLE
fix(webrtc): recaptcha error handling

### DIFF
--- a/src/placeos-rest-api/controllers/webrtc.cr
+++ b/src/placeos-rest-api/controllers/webrtc.cr
@@ -76,9 +76,11 @@ module PlaceOS::Api
             else
               raise Error::RecaptchaFailed.new("error verifying recaptcha response")
             end
+          rescue error : Error::RecaptchaFailed
+            raise error
           rescue error
             # We don't want chat to be out of action if google is down, so we'll continue
-            Log.error(exception: error) { "recaptcha failed" }
+            Log.error(exception: error) { "recaptcha verification failed" }
           end
         end
       else


### PR DESCRIPTION
Fix reCAPTCHA enforcement in WebRTC `guest_entry`: the generic `rescue error` was catching and swallowing `Error::RecaptchaFailed` alongside transient network errors, allowing guests to obtain a valid JWT even when reCAPTCHA verification failed. This adds a specific `rescue error : Error::RecaptchaFailed` clause to re-raise it before the generic rescue.