### PR TITLE
test(websocket): gate the bind/debug/ignore specs on the response arriving

### DIFF
--- a/spec/websocket/session_spec.cr
+++ b/spec/websocket/session_spec.cr
@@ -65,7 +65,7 @@ module PlaceOS::Api::WebSocket
         status_name = "nugget"
 
         id = rand(10).to_i64
-        results = test_websocket_api(Systems.base_route, Spec::Authentication.headers) do |ws, control_system, mod|
+        results = test_websocket_api(Systems.base_route, Spec::Authentication.headers) do |ws, control_system, mod, updates|
           request = {
             id:          id,
             system_id:   control_system.id.as(String),
@@ -74,9 +74,9 @@ module PlaceOS::Api::WebSocket
             command:     Session::Request::Command::Bind,
           }
           ws.send Session::Request.new(**request).to_json
-          sleep 100.milliseconds
+          wait_for_updates(updates, 1)
           ws.send Session::Request.new(**request.merge({command: Session::Request::Command::Bind})).to_json
-          sleep 100.milliseconds
+          wait_for_updates(updates, 2)
         end
 
         updates, control_system, mod = results
@@ -121,7 +121,7 @@ module PlaceOS::Api::WebSocket
         status_name = "nugget"
 
         id = rand(10).to_i64
-        updates, _, _ = test_websocket_api(Systems.base_route, Spec::Authentication.headers) do |ws, control_system, mod|
+        updates, _, _ = test_websocket_api(Systems.base_route, Spec::Authentication.headers) do |ws, control_system, mod, updates|
           request = {
             id:          id,
             system_id:   control_system.id.as(String),
@@ -130,7 +130,7 @@ module PlaceOS::Api::WebSocket
             command:     Session::Request::Command::Debug,
           }
           ws.send Session::Request.new(**request).to_json
-          sleep 100.milliseconds
+          wait_for_updates(updates, 1)
         end
 
         # Check all messages received
@@ -143,7 +143,7 @@ module PlaceOS::Api::WebSocket
         status_name = "nugget"
 
         id = rand(10).to_i64
-        updates, _, _ = test_websocket_api(Systems.base_route, Spec::Authentication.headers) do |ws, control_system, mod|
+        updates, _, _ = test_websocket_api(Systems.base_route, Spec::Authentication.headers) do |ws, control_system, mod, updates|
           request = {
             id:          id,
             system_id:   control_system.id.as(String),
@@ -152,7 +152,7 @@ module PlaceOS::Api::WebSocket
             command:     Session::Request::Command::Ignore,
           }
           ws.send Session::Request.new(**request).to_json
-          sleep 100.milliseconds
+          wait_for_updates(updates, 1)
         end
 
         # Check all messages received


### PR DESCRIPTION
Three specs in `session_spec.cr` sent a websocket request, slept a fixed `100.milliseconds`, then asserted on `updates.size`. That's a race rather than a wait — under any extra load the response hasn't arrived and the spec fails with `expected 1, got 0`, pointing at websockets when the branch under test had nothing to do with them.

`wait_for_updates` already exists in this file for exactly this purpose, with a comment saying so, and the `receives updates` spec already uses it. `unbind`, `debug` and `ignore` were simply never converted.

### How I found it

Merging the Azure consent stack (#440 → #441 → #442). After rebasing #442 onto master, `websocket API debug` failed **twice in a row**, while passing on master and on every earlier run of the same code. #442 only touches `tenant_consent.cr` and adds one utility — it cannot affect a websocket subscription. What it does add is six examples with Redis round-trips, and that was enough to push the fixed sleep over.

So this is a latent flake that gets exposed by any branch that adds work to the suite, which makes it worth fixing rather than retrying past.

The helper polls to a 5-second deadline and raises on timeout, so a real regression still fails — it just stops failing for the wrong reason.

`exec` (line ~111) still uses a fixed sleep; it goes through `test_websocket_exec`, which doesn't expose `updates` to its block. Left alone rather than widened here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)